### PR TITLE
Only add finalizer and update instance if necessary

### DIFF
--- a/controllers/octaviaapi_controller.go
+++ b/controllers/octaviaapi_controller.go
@@ -483,10 +483,12 @@ func (r *OctaviaAPIReconciler) reconcileUpgrade(ctx context.Context, instance *o
 func (r *OctaviaAPIReconciler) reconcileNormal(ctx context.Context, instance *octaviav1.OctaviaAPI, helper *helper.Helper) (ctrl.Result, error) {
 	r.Log.Info("Reconciling Service")
 
-	// If the service object doesn't have our finalizer, add it.
-	controllerutil.AddFinalizer(instance, helper.GetFinalizer())
-	// Register the finalizer immediately to avoid orphaning resources on delete
-	if err := r.Update(ctx, instance); err != nil {
+	if !controllerutil.ContainsFinalizer(instance, helper.GetFinalizer()) {
+		// If the service object doesn't have our finalizer, add it.
+		controllerutil.AddFinalizer(instance, helper.GetFinalizer())
+		// Register the finalizer immediately to avoid orphaning resources on delete
+		err := r.Update(ctx, instance)
+
 		return ctrl.Result{}, err
 	}
 


### PR DESCRIPTION
We should only attempt to add finalizers in reconcileNormal() if they are missing from the instance being reconciled, and if such action is needed, we should end that reconcile after updating the instance to avoid potentially reconciling again with an outdated version of the instance (see [1] for details).

[1] https://github.com/openstack-k8s-operators/ovn-operator/pull/1#discussion_r997014701