### PR TITLE
Fix defaulting PasswordSelectors

### DIFF
--- a/api/v1beta1/octaviaapi_types.go
+++ b/api/v1beta1/octaviaapi_types.go
@@ -73,7 +73,8 @@ type OctaviaAPISpec struct {
 	Secret string `json:"secret,omitempty"`
 
 	// +kubebuilder:validation:Optional
-	// PasswordSelectors - Selectors to identify the DB and AdminUser password from the Secret
+	// +kubebuilder:default={database: OctaviaDatabasePassword, service: OctaviaPassword}
+	// PasswordSelectors - Selectors to identify the DB and ServiceUser password from the Secret
 	PasswordSelectors PasswordSelector `json:"passwordSelectors,omitempty"`
 
 	// +kubebuilder:validation:Optional

--- a/config/crd/bases/octavia.openstack.org_octaviaapis.yaml
+++ b/config/crd/bases/octavia.openstack.org_octaviaapis.yaml
@@ -95,8 +95,11 @@ spec:
                   this service
                 type: object
               passwordSelectors:
+                default:
+                  database: OctaviaDatabasePassword
+                  service: OctaviaPassword
                 description: PasswordSelectors - Selectors to identify the DB and
-                  AdminUser password from the Secret
+                  ServiceUser password from the Secret
                 properties:
                   database:
                     default: OctaviaDatabasePassword


### PR DESCRIPTION
When a CRD has an optional struct field the defaulting of that field needs special care. Both the field with the struct type need a full default value defined and each individual subfields in the struct needs default value defined. Otherwise in the first reconcile call the PasswordSelectors is empty and then in the second reconcile it is filled.

Now documented via https://github.com/openstack-k8s-operators/docs/pull/12