### PR TITLE
Use own octavia user for other services too

### DIFF
--- a/templates/octaviaapi/config/octavia.conf
+++ b/templates/octaviaapi/config/octavia.conf
@@ -89,7 +89,7 @@ auth_type = password
 project_domain_name = Default
 user_domain_name = default
 region_name = regionOne
-username = nova
+username = {{ .ServiceUser }}
 [cinder]
 # region_name=regionOne
 # endpoint_type=internalURL
@@ -102,7 +102,7 @@ auth_type = password
 project_domain_name = Default
 user_domain_name = default
 region_name = regionOne
-username = neutron
+username = {{ .ServiceUser }}
 [quotas]
 [audit]
 [audit_middleware_notifications]


### PR DESCRIPTION
Change according to proposals:

 https://github.com/openstack-k8s-operators/cinder-operator/pull/107
 https://github.com/openstack-k8s-operators/neutron-operator/pull/93