### PR TITLE
Remove unused credential from octavia.conf

### DIFF
--- a/templates/octaviaapi/config/octavia.conf
+++ b/templates/octaviaapi/config/octavia.conf
@@ -84,12 +84,8 @@ disable_local_log_storage=False
 # auth_url={{ .KeystonePublicURL }}/v3
 # region_name=regionOne
 [nova]
-auth_url = {{ .KeystonePublicURL }}
-auth_type = password
-project_domain_name = Default
-user_domain_name = default
-region_name = regionOne
-username = nova
+# region_name=regionOne
+# endpoint_type=internalURL
 [cinder]
 # region_name=regionOne
 # endpoint_type=internalURL
@@ -97,12 +93,8 @@ username = nova
 # region_name=regionOne
 # endpoint_type=internalURL
 [neutron]
-auth_url = {{ .KeystonePublicURL }}
-auth_type = password
-project_domain_name = Default
-user_domain_name = default
-region_name = regionOne
-username = neutron
+# region_name=regionOne
+# endpoint_type=internalURL
 [quotas]
 [audit]
 [audit_middleware_notifications]


### PR DESCRIPTION
The current octavia does not accept credentials in [nova] or [neutron] and use the one configured in the [service_auth] section. This removes the unused credential from these two sections.