### PR TITLE
Use internal endpoints for service interactions

### DIFF
--- a/controllers/octaviaapi_controller.go
+++ b/controllers/octaviaapi_controller.go
@@ -663,13 +663,18 @@ func (r *OctaviaAPIReconciler) generateServiceConfigMaps(
 	if err != nil {
 		return err
 	}
-	authURL, err := keystoneAPI.GetEndpoint(endpoint.EndpointPublic)
+	keystoneInternalURL, err := keystoneAPI.GetEndpoint(endpoint.EndpointInternal)
+	if err != nil {
+		return err
+	}
+	keystonePublicURL, err := keystoneAPI.GetEndpoint(endpoint.EndpointPublic)
 	if err != nil {
 		return err
 	}
 	templateParameters := make(map[string]interface{})
 	templateParameters["ServiceUser"] = instance.Spec.ServiceUser
-	templateParameters["KeystonePublicURL"] = authURL
+	templateParameters["KeystoneInternalURL"] = keystoneInternalURL
+	templateParameters["KeystonePublicURL"] = keystonePublicURL
 
 	cms := []util.Template{
 		// ScriptsConfigMap

--- a/templates/octaviaapi/config/octavia.conf
+++ b/templates/octaviaapi/config/octavia.conf
@@ -21,7 +21,7 @@ stats_update_threads=4
 # heartbeat_key=FIXMEkey1
 [keystone_authtoken]
 www_authenticate_uri={{ .KeystonePublicURL }}
-auth_url={{ .KeystonePublicURL }}
+auth_url={{ .KeystoneInternalURL }}
 username={{ .ServiceUser }}
 # password=FIXMEpw3
 project_name=service
@@ -31,13 +31,13 @@ auth_type=password
 # memcache_use_advanced_pool=True
 # memcached_servers=FIXMEhost1:11211
 # region_name=regionOne
-# interface=internal
+interface=internal
 [certificates]
 # ca_certificate=/etc/octavia/certs/ca_01.pem
 # ca_private_key=/etc/octavia/certs/private/cakey.pem
 # ca_private_key_passphrase=FIXMEpw4
 # server_certs_key_passphrase=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
-# endpoint_type=internalURL
+endpoint_type=internalURL
 [compute]
 [networking]
 port_detach_timeout=300
@@ -81,20 +81,20 @@ disable_local_log_storage=False
 # password=FIXMEpw3
 # username=octavia
 # auth_type=password
-# auth_url={{ .KeystonePublicURL }}/v3
+# auth_url={{ .KeystoneInternalURL }}
 # region_name=regionOne
 [nova]
 # region_name=regionOne
-# endpoint_type=internalURL
+endpoint_type=internalURL
 [cinder]
 # region_name=regionOne
-# endpoint_type=internalURL
+endpoint_type=internalURL
 [glance]
 # region_name=regionOne
-# endpoint_type=internalURL
+endpoint_type=internalURL
 [neutron]
 # region_name=regionOne
-# endpoint_type=internalURL
+endpoint_type=internalURL
 [quotas]
 [audit]
 [audit_middleware_notifications]


### PR DESCRIPTION
This change ensures Octavia uses internal endpoints to interact with the other services, instead of public endpoints.