### PR TITLE
Add basic KUTTL tests for octavia operator

### DIFF
--- a/kuttl-test.yaml
+++ b/kuttl-test.yaml
@@ -1,0 +1,25 @@
+#
+# EXECUTION (from install_yamls repo root):
+#
+#   make octavia_kuttl
+#
+# ASSUMPTIONS:
+#
+# 1. Latest version of kuttl is installed at /usr/local/bin/kubectl-kuttl
+#    - wget https://github.com/kudobuilder/kuttl/releases/download/v0.11.1/kubectl-kuttl_0.11.1_linux_x86_64
+#    - mv kubectl-kuttl_0.11.1_linux_x86_64 /usr/local/bin/kubectl-kuttl
+#    - chmod 755 /usr/local/bin/kubectl-kuttl
+# 2. An OCP 4.10+ CRC cluster with Podified Operators has been deployed
+# 3. CLI user has access to $KUBECONFIG
+# 4. The environment variable INSTALL_YAMLS is set to the the path of the
+#    install_yamls repo
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestSuite
+reportFormat: JSON
+reportName: kuttl-test-octavia
+namespace: openstack
+timeout: 180
+parallel: 1
+suppress:
+  - events                     # Remove spammy event logs

--- a/tests/kuttl/common/assert_sample_deployment.yaml
+++ b/tests/kuttl/common/assert_sample_deployment.yaml
@@ -1,0 +1,251 @@
+#
+# Check for:
+#
+# - 1 OctaviaAPI CR
+# - Deployment with 1 Pod for OctaviaAPI CR
+# - Octavia-admin Service
+# - Octavia-internal Service
+# - Octavia-public Service
+# - Octavia-admin Route
+# - Octavia-internal Route
+# - Octavia-public Route
+
+apiVersion: octavia.openstack.org/v1beta1
+kind: OctaviaAPI
+metadata:
+  finalizers:
+  - OctaviaAPI
+  name: octavia
+  namespace: openstack
+spec:
+  containerImage: quay.io/tripleozedcentos9/openstack-octavia-api:current-tripleo
+  customServiceConfig: |
+    [DEFAULT]
+    debug = true
+  databaseInstance: openstack
+  databaseUser: octavia
+  debug:
+    dbSync: false
+    service: false
+  passwordSelectors:
+    service: OctaviaPassword
+    database: OctaviaDatabasePassword
+  preserveJobs: false
+  replicas: 1
+  resources:
+    requests:
+      cpu: "1.0"
+      memory: 500Mi
+  secret: osp-secret
+  serviceUser: octavia
+status:
+  databaseHostname: openstack
+  readyCount: 1
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: octavia
+  namespace: openstack
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        service: octavia
+    spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: service
+                  operator: In
+                  values:
+                  - octavia
+              topologyKey: kubernetes.io/hostname
+            weight: 1
+      containers:
+      - args:
+        - -c
+        - /usr/local/bin/kolla_set_configs && /usr/local/bin/kolla_start
+        command:
+        - /bin/bash
+        image: quay.io/tripleozedcentos9/openstack-octavia-api:current-tripleo
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /healthcheck
+            port: 9876
+            scheme: HTTP
+          initialDelaySeconds: 3
+          periodSeconds: 13
+          successThreshold: 1
+          timeoutSeconds: 15
+        name: octavia-api
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /healthcheck
+            port: 9876
+            scheme: HTTP
+          initialDelaySeconds: 5
+          periodSeconds: 15
+          successThreshold: 1
+          timeoutSeconds: 15
+        resources:
+          requests:
+            cpu: "1"
+            memory: 500Mi
+      initContainers:
+      - args:
+        - -c
+        - /usr/local/bin/container-scripts/init.sh
+        command:
+        - /bin/bash
+        env:
+        - name: DatabasePassword
+          valueFrom:
+            secretKeyRef:
+              key: OctaviaDatabasePassword
+              name: osp-secret
+        - name: AdminPassword
+          valueFrom:
+            secretKeyRef:
+              key: OctaviaPassword
+              name: osp-secret
+        - name: DatabaseHost
+          value: openstack
+        - name: DatabaseName
+          value: octavia
+        - name: DatabaseUser
+          value: octavia
+        image: quay.io/tripleozedcentos9/openstack-octavia-api:current-tripleo
+        imagePullPolicy: IfNotPresent
+        name: init
+        resources: {}
+      restartPolicy: Always
+      serviceAccount: octavia-operator-octavia
+      serviceAccountName: octavia-operator-octavia
+status:
+  availableReplicas: 1
+  replicas: 1
+---
+# the openshift annotations can't be checked through the deployment above
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    openshift.io/scc: anyuid
+  labels:
+    service: octavia
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    admin: "true"
+    service: octavia
+  name: octavia-admin
+  namespace: openstack
+spec:
+  ports:
+    - name: octavia-admin
+  selector:
+    service: octavia
+  type: ClusterIP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    internal: "true"
+    service: octavia
+  name: octavia-internal
+  namespace: openstack
+spec:
+  ports:
+    - name: octavia-internal
+  selector:
+    service: octavia
+  type: ClusterIP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    public: "true"
+    service: octavia
+  name: octavia-public
+  namespace: openstack
+spec:
+  ports:
+    - name: octavia-public
+  selector:
+    service: octavia
+  type: ClusterIP
+---
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: octavia-admin
+  labels:
+    admin: "true"
+    service: octavia
+  namespace: openstack
+spec:
+  port:
+    targetPort: octavia-admin
+  to:
+    kind: Service
+    name: octavia-admin
+---
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: octavia-internal
+  labels:
+    internal: "true"
+    service: octavia
+  namespace: openstack
+spec:
+  port:
+    targetPort: octavia-internal
+  to:
+    kind: Service
+    name: octavia-internal
+---
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: octavia-public
+  labels:
+    public: "true"
+    service: octavia
+  namespace: openstack
+spec:
+  port:
+    targetPort: octavia-public
+  to:
+    kind: Service
+    name: octavia-public
+---
+# the actual addresses of the apiEndpoints are platform specific, so we can't rely on 
+# kuttl asserts to check them. This short script gathers the addresses and checks that
+# the three endpoints are defined and their addresses follow the default pattern
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+namespaced: true
+commands:
+  - script: |
+      template='{{.status.apiEndpoint.admin}}{{":"}}{{.status.apiEndpoint.internal}}{{":"}}{{.status.apiEndpoint.public}}{{"\n"}}'                                                        
+      regex="http:\/\/octavia-admin-openstack\.apps.*:http:\/\/octavia-internal-openstack\.apps.*:http:\/\/octavia-public-openstack\.apps.*"
+      apiEndpoints=$(oc get -n openstack OctaviaAPI octavia -o go-template="$template") 
+      matches=$(echo $apiEndpoints | sed -e "s?$regex??")
+      if [ -z "$matches" ]; then
+        exit 0
+      else
+        exit 1
+      fi

--- a/tests/kuttl/tests/octavia_scale/01-assert.yaml
+++ b/tests/kuttl/tests/octavia_scale/01-assert.yaml
@@ -1,0 +1,1 @@
+../../common/assert_sample_deployment.yaml

--- a/tests/kuttl/tests/octavia_scale/01-deploy-octavia.yaml
+++ b/tests/kuttl/tests/octavia_scale/01-deploy-octavia.yaml
@@ -1,0 +1,6 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - script: |
+      PWD=$INSTALL_YAMLS
+      make -C $INSTALL_YAMLS octavia_deploy

--- a/tests/kuttl/tests/octavia_scale/02-assert.yaml
+++ b/tests/kuttl/tests/octavia_scale/02-assert.yaml
@@ -1,0 +1,27 @@
+#
+# Check for:
+#
+# - 1 OctaviaAPI CR
+# - 3 Pods for OctaviaAPI CR
+#
+
+apiVersion: octavia.openstack.org/v1beta1
+kind: OctaviaAPI
+metadata:
+  finalizers:
+  - OctaviaAPI
+  name: octavia
+  namespace: openstack
+spec:
+  replicas: 3
+status:
+  readyCount: 3
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: octavia
+spec:
+  replicas: 3
+status:
+  availableReplicas: 3

--- a/tests/kuttl/tests/octavia_scale/02-scale-octaviaapi.yaml
+++ b/tests/kuttl/tests/octavia_scale/02-scale-octaviaapi.yaml
@@ -1,0 +1,5 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - script: |
+      oc patch octaviaapi -n openstack octavia --type='json' -p='[{"op": "replace", "path": "/spec/replicas", "value":3}]'

--- a/tests/kuttl/tests/octavia_scale/03-assert.yaml
+++ b/tests/kuttl/tests/octavia_scale/03-assert.yaml
@@ -1,0 +1,28 @@
+#
+# Check for:
+#
+# - 1 OctaviaAPI CR
+# - 1 Pods for OctaviaAPI CR
+#
+
+apiVersion: octavia.openstack.org/v1beta1
+kind: OctaviaAPI
+metadata:
+  finalizers:
+  - OctaviaAPI
+  name: octavia
+  namespace: openstack
+spec:
+  replicas: 1
+status:
+  readyCount: 1
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: octavia
+  namespace: openstack
+spec:
+  replicas: 1
+status:
+  availableReplicas: 1

--- a/tests/kuttl/tests/octavia_scale/03-scale-down-octaviaapi.yaml
+++ b/tests/kuttl/tests/octavia_scale/03-scale-down-octaviaapi.yaml
@@ -1,0 +1,5 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - script: |
+      oc patch octaviaapi -n openstack octavia --type='json' -p='[{"op": "replace", "path": "/spec/replicas", "value":1}]'

--- a/tests/kuttl/tests/octavia_scale/04-assert.yaml
+++ b/tests/kuttl/tests/octavia_scale/04-assert.yaml
@@ -1,0 +1,43 @@
+#
+# Check for:
+#
+# - 1 OctaviaAPI CR with 0 replicas
+# - Octavia Deployment with 0 Pods
+#
+
+apiVersion: octavia.openstack.org/v1beta1
+kind: OctaviaAPI
+metadata:
+  finalizers:
+  - OctaviaAPI
+  name: octavia
+  namespace: openstack
+spec:
+  containerImage: quay.io/tripleozedcentos9/openstack-octavia-api:current-tripleo
+  customServiceConfig: |
+    [DEFAULT]
+    debug = true
+  databaseInstance: openstack
+  databaseUser: octavia
+  debug:
+    dbSync: false
+    service: false
+  passwordSelectors:
+    service: OctaviaPassword
+    database: OctaviaDatabasePassword
+  preserveJobs: false
+  replicas: 0
+  resources:
+    requests:
+      cpu: "1.0"
+      memory: 500Mi
+  secret: osp-secret
+status:
+  databaseHostname: openstack
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: octavia
+spec:
+  replicas: 0

--- a/tests/kuttl/tests/octavia_scale/04-errors.yaml
+++ b/tests/kuttl/tests/octavia_scale/04-errors.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    openshift.io/scc: anyuid
+  labels:
+    service: octavia

--- a/tests/kuttl/tests/octavia_scale/04-scale-down-zero-octaviaapi.yaml
+++ b/tests/kuttl/tests/octavia_scale/04-scale-down-zero-octaviaapi.yaml
@@ -1,0 +1,5 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - script: |
+      oc patch octaviaapi -n openstack octavia --type='json' -p='[{"op": "replace", "path": "/spec/replicas", "value":0}]'

--- a/tests/kuttl/tests/octavia_scale/05-cleanup-octavia.yaml
+++ b/tests/kuttl/tests/octavia_scale/05-cleanup-octavia.yaml
@@ -1,0 +1,6 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - script: |
+      PWD=$INSTALL_YAMLS
+      make -C $INSTALL_YAMLS octavia_deploy_cleanup

--- a/tests/kuttl/tests/octavia_scale/05-errors.yaml
+++ b/tests/kuttl/tests/octavia_scale/05-errors.yaml
@@ -1,0 +1,121 @@
+#
+# Check for:
+#
+# No OctaviaAPI CR
+# No Deployment for OctaviaAPI CR
+# No Pods in octavia Deployment
+# No Octavia Services
+# No Octavia Routes
+#
+apiVersion: octavia.openstack.org/v1beta1
+kind: OctaviaAPI
+metadata:
+  finalizers:
+  - OctaviaAPI
+  name: octavia
+  namespace: openstack
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: octavia
+  namespace: openstack
+---
+# the openshift annotations can't be checked through the deployment above
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    openshift.io/scc: anyuid
+  labels:
+    service: octavia
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    admin: "true"
+    service: octavia
+  name: octavia-admin
+  namespace: openstack
+spec:
+  ports:
+    - name: octavia-admin
+  selector:
+    service: octavia
+  type: ClusterIP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    internal: "true"
+    service: octavia
+  name: octavia-internal
+  namespace: openstack
+spec:
+  ports:
+    - name: octavia-internal
+  selector:
+    service: octavia
+  type: ClusterIP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    public: "true"
+    service: octavia
+  name: octavia-public
+  namespace: openstack
+spec:
+  ports:
+    - name: octavia-public
+  selector:
+    service: octavia
+  type: ClusterIP
+---
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: octavia-admin
+  labels:
+    admin: "true"
+    service: octavia
+  namespace: openstack
+spec:
+  port:
+    targetPort: octavia-admin
+  to:
+    kind: Service
+    name: octavia-admin
+---
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: octavia-internal
+  labels:
+    internal: "true"
+    service: octavia
+  namespace: openstack
+spec:
+  port:
+    targetPort: octavia-internal
+  to:
+    kind: Service
+    name: octavia-internal
+---
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: octavia-public
+  labels:
+    public: "true"
+    service: octavia
+  namespace: openstack
+spec:
+  port:
+    targetPort: octavia-public
+  to:
+    kind: Service
+    name: octavia-public


### PR DESCRIPTION
These tests cover basic operations: deployment, scaling up, scaling down
and clean up. The tests make use code from the install_yamls repo to reuse
some operations like the deployment of the keystone, octavia and mariadb db
operators, as well as the cleanup from previous runs.
