### PR TITLE
Simplify pattern to exclude bin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,10 +5,9 @@
 *.dll
 *.so
 *.dylib
-bin
+/bin
 testbin/*
 __debug_bin
-!/templates/octaviaapi/bin
 
 # Test binary, build with `go test -c`
 *.test


### PR DESCRIPTION
We can exclude the top-directory instead of using the pattern which can match subdirectories.

Signed-off-by: Takashi Kajinami <tkajinam@redhat.com>