### PR TITLE
Remove resource requests from config samples

### DIFF
--- a/config/samples/octavia_v1beta1_octavia.yaml
+++ b/config/samples/octavia_v1beta1_octavia.yaml
@@ -18,10 +18,6 @@ spec:
   customServiceConfig: |
     [DEFAULT]
     debug = true
-  resources:
-    requests:
-      memory: "500Mi"
-      cpu: "1.0"
   octaviaAPI:
     databaseInstance: openstack
     databaseUser: octavia
@@ -38,8 +34,3 @@ spec:
     customServiceConfig: |
       [DEFAULT]
       debug = true
-    resources:
-      requests:
-        memory: "500Mi"
-        cpu: "1.0"
-

--- a/tests/kuttl/common/assert_sample_deployment.yaml
+++ b/tests/kuttl/common/assert_sample_deployment.yaml
@@ -47,10 +47,6 @@ spec:
       database: OctaviaDatabasePassword
     preserveJobs: false
     replicas: 1
-    resources:
-      requests:
-        cpu: "1.0"
-        memory: 500Mi
     secret: osp-secret
     serviceUser: octavia
 status:
@@ -110,11 +106,7 @@ spec:
           periodSeconds: 15
           successThreshold: 1
           timeoutSeconds: 15
-        resources:
-          requests:
-            cpu: "1"
-            memory: 500Mi
-      - env: 
+      - env:
         - name: CONFIG_HASH
         - name: KOLLA_CONFIG_FILE
         - name: KOLLA_CONFIG_STRATEGY
@@ -141,10 +133,6 @@ spec:
           periodSeconds: 15
           successThreshold: 1
           timeoutSeconds: 15
-        resources:
-          requests:
-            cpu: "1"
-            memory: 500Mi
       initContainers:
       - args:
         - -c


### PR DESCRIPTION
It's necessary in the config samples and would normally be deployment specific. Many other operators do not include them.