### PR TITLE
 Remove install_yamls dependency for kuttl tests

### DIFF
--- a/tests/kuttl/tests/octavia_scale/01-deploy-octavia.yaml
+++ b/tests/kuttl/tests/octavia_scale/01-deploy-octavia.yaml
@@ -1,6 +1,1 @@
-apiVersion: kuttl.dev/v1beta1
-kind: TestStep
-commands:
-  - script: |
-      PWD=$INSTALL_YAMLS
-      make -C $INSTALL_YAMLS octavia_deploy
+../../../../config/samples/octavia_v1beta1_octavia.yaml

--- a/tests/kuttl/tests/octavia_scale/05-cleanup-octavia.yaml
+++ b/tests/kuttl/tests/octavia_scale/05-cleanup-octavia.yaml
@@ -1,6 +1,7 @@
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
-commands:
-  - script: |
-      PWD=$INSTALL_YAMLS
-      make -C $INSTALL_YAMLS octavia_deploy_cleanup
+delete:
+- apiVersion: octavia.openstack.org/v1beta1
+  kind: Octavia
+  name: octavia
+  namespace: openstack


### PR DESCRIPTION
Instead of using install_yamls targets for deploying and cleaning up
octavia, use the CR sample from config/samples. This removes a possible
circular dependency issue when using install_yamls to run the jobs and
to run some test steps.
