### PR TITLE
Copy rendered CRD files dir to /api/bases in make manifests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -87,7 +87,8 @@ help: ## Display this help.
 
 .PHONY: manifests
 manifests: controller-gen ## Generate WebhookConfiguration, ClusterRole and CustomResourceDefinition objects.
-	$(CONTROLLER_GEN) rbac:roleName=manager-role crd webhook paths="./..." output:crd:artifacts:config=config/crd/bases
+	$(CONTROLLER_GEN) rbac:roleName=manager-role crd webhook paths="./..." output:crd:artifacts:config=config/crd/bases && \
+	rm -f api/bases/* && cp -a config/crd/bases api/
 
 .PHONY: generate
 generate: controller-gen ## Generate code containing DeepCopy, DeepCopyInto, and DeepCopyObject method implementations.

--- a/api/bases/octavia.openstack.org_octavia.yaml
+++ b/api/bases/octavia.openstack.org_octavia.yaml
@@ -1,0 +1,363 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.10.0
+  creationTimestamp: null
+  name: octavia.octavia.openstack.org
+spec:
+  group: octavia.openstack.org
+  names:
+    kind: Octavia
+    listKind: OctaviaList
+    plural: octavia
+    singular: octavia
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Status
+      jsonPath: .status.conditions[0].status
+      name: Status
+      type: string
+    - description: Message
+      jsonPath: .status.conditions[0].message
+      name: Message
+      type: string
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: Octavia is the Schema for the octavia API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: OctaviaSpec defines the desired state of Octavia
+            properties:
+              customServiceConfig:
+                default: '# add your customization here'
+                description: CustomServiceConfig - customize the service config using
+                  this parameter to change service defaults, or overwrite rendered
+                  information using raw OpenStack config format. The content gets
+                  added to to /etc/<service>/<service>.conf.d directory as custom.conf
+                  file.
+                type: string
+              databaseInstance:
+                description: MariaDB instance name Right now required by the maridb-operator
+                  to get the credentials from the instance to create the DB Might
+                  not be required in future
+                type: string
+              databaseUser:
+                default: octavia
+                description: 'DatabaseUser - optional username used for octavia DB,
+                  defaults to octavia TODO: -> implement needs work in mariadb-operator,
+                  right now only octavia'
+                type: string
+              debug:
+                description: Debug - enable debug for different deploy stages. If
+                  an init container is used, it runs and the actual action pod gets
+                  started with sleep infinity
+                properties:
+                  dbSync:
+                    default: false
+                    description: DBSync enable debug
+                    type: boolean
+                  service:
+                    default: false
+                    description: Service enable debug
+                    type: boolean
+                type: object
+              defaultConfigOverwrite:
+                additionalProperties:
+                  type: string
+                description: 'ConfigOverwrite - interface to overwrite default config
+                  files like e.g. logging.conf or policy.json. But can also be used
+                  to add additional files. Those get added to the service config dir
+                  in /etc/<service> . TODO: -> implement'
+                type: object
+              nodeSelector:
+                additionalProperties:
+                  type: string
+                description: NodeSelector to target subset of worker nodes running
+                  this service
+                type: object
+              octaviaAPI:
+                description: OctaviaAPI - Spec definition for the API service of the
+                  Octavia deployment
+                properties:
+                  containerImage:
+                    description: Octavia Container Image URL
+                    type: string
+                  customServiceConfig:
+                    default: '# add your customization here'
+                    description: CustomServiceConfig - customize the service config
+                      using this parameter to change service defaults, or overwrite
+                      rendered information using raw OpenStack config format. The
+                      content gets added to to /etc/<service>/<service>.conf.d directory
+                      as custom.conf file.
+                    type: string
+                  databaseHostname:
+                    description: DatabaseHostname - Octavia DB hostname
+                    type: string
+                  databaseInstance:
+                    description: MariaDB instance name Right now required by the maridb-operator
+                      to get the credentials from the instance to create the DB Might
+                      not be required in future
+                    type: string
+                  databaseUser:
+                    default: octavia
+                    description: 'DatabaseUser - optional username used for octavia
+                      DB, defaults to octavia TODO: -> implement needs work in mariadb-operator,
+                      right now only octavia'
+                    type: string
+                  debug:
+                    description: Debug - enable debug for different deploy stages.
+                      If an init container is used, it runs and the actual action
+                      pod gets started with sleep infinity
+                    properties:
+                      dbSync:
+                        default: false
+                        description: DBSync enable debug
+                        type: boolean
+                      service:
+                        default: false
+                        description: Service enable debug
+                        type: boolean
+                    type: object
+                  defaultConfigOverwrite:
+                    additionalProperties:
+                      type: string
+                    description: 'ConfigOverwrite - interface to overwrite default
+                      config files like e.g. logging.conf or policy.json. But can
+                      also be used to add additional files. Those get added to the
+                      service config dir in /etc/<service> . TODO: -> implement'
+                    type: object
+                  nodeSelector:
+                    additionalProperties:
+                      type: string
+                    description: NodeSelector to target subset of worker nodes running
+                      this service
+                    type: object
+                  passwordSelectors:
+                    default:
+                      database: OctaviaDatabasePassword
+                      service: OctaviaPassword
+                    description: PasswordSelectors - Selectors to identify the DB
+                      and ServiceUser password from the Secret
+                    properties:
+                      database:
+                        default: OctaviaDatabasePassword
+                        description: 'Database - Selector to get the octavia Database
+                          user password from the Secret TODO: not used, need change
+                          in mariadb-operator'
+                        type: string
+                      service:
+                        default: OctaviaPassword
+                        description: Service - Selector to get the service user password
+                          from the Secret
+                        type: string
+                    type: object
+                  preserveJobs:
+                    default: false
+                    description: PreserveJobs - do not delete jobs after they finished
+                      e.g. to check logs
+                    type: boolean
+                  replicas:
+                    default: 1
+                    description: Replicas of octavia API to run
+                    format: int32
+                    maximum: 32
+                    minimum: 0
+                    type: integer
+                  resources:
+                    description: Resources - Compute Resources required by this service
+                      (Limits/Requests). https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                    properties:
+                      claims:
+                        description: "Claims lists the names of resources, defined
+                          in spec.resourceClaims, that are used by this container.
+                          \n This is an alpha field and requires enabling the DynamicResourceAllocation
+                          feature gate. \n This field is immutable."
+                        items:
+                          description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                          properties:
+                            name:
+                              description: Name must match the name of one entry in
+                                pod.spec.resourceClaims of the Pod where this field
+                                is used. It makes that resource available inside a
+                                container.
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Limits describes the maximum amount of compute
+                          resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Requests describes the minimum amount of compute
+                          resources required. If Requests is omitted for a container,
+                          it defaults to Limits if that is explicitly specified, otherwise
+                          to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                        type: object
+                    type: object
+                  secret:
+                    description: Secret containing OpenStack password information
+                      for octavia OctaviaDatabasePassword, AdminPassword
+                    type: string
+                  serviceUser:
+                    default: octavia
+                    description: ServiceUser - service user name
+                    type: string
+                required:
+                - containerImage
+                - databaseInstance
+                - secret
+                type: object
+              passwordSelectors:
+                default:
+                  database: OctaviaDatabasePassword
+                  service: OctaviaPassword
+                description: PasswordSelectors - Selectors to identify the DB and
+                  ServiceUser password from the Secret
+                properties:
+                  database:
+                    default: OctaviaDatabasePassword
+                    description: 'Database - Selector to get the octavia Database
+                      user password from the Secret TODO: not used, need change in
+                      mariadb-operator'
+                    type: string
+                  service:
+                    default: OctaviaPassword
+                    description: Service - Selector to get the service user password
+                      from the Secret
+                    type: string
+                type: object
+              preserveJobs:
+                default: false
+                description: PreserveJobs - do not delete jobs after they finished
+                  e.g. to check logs
+                type: boolean
+              secret:
+                description: Secret containing OpenStack password information for
+                  octavia OctaviaDatabasePassword, AdminPassword
+                type: string
+              serviceUser:
+                default: octavia
+                description: ServiceUser - service user name
+                type: string
+            required:
+            - databaseInstance
+            - octaviaAPI
+            - secret
+            type: object
+          status:
+            description: OctaviaStatus defines the observed state of Octavia
+            properties:
+              apiEndpoint:
+                additionalProperties:
+                  type: string
+                description: API endpoint
+                type: object
+              apireadyCount:
+                description: ReadyCount of octavia API instances
+                format: int32
+                type: integer
+              conditions:
+                description: Conditions
+                items:
+                  description: Condition defines an observation of a API resource
+                    operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another. This should be when the underlying condition changed.
+                        If that is not known, then using the time when the API field
+                        changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition
+                        in CamelCase.
+                      type: string
+                    severity:
+                      description: Severity provides a classification of Reason code,
+                        so the current situation is immediately understandable and
+                        could act accordingly. It is meant for situations where Status=False
+                        and it should be indicated if it is just informational, warning
+                        (next reconciliation might fix it) or an error (e.g. DB create
+                        issue and no actions to automatically resolve the issue can/should
+                        be done). For conditions where Status=Unknown or Status=True
+                        the Severity should be SeverityNone.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of condition in CamelCase.
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - status
+                  - type
+                  type: object
+                type: array
+              databaseHostname:
+                description: Octavia Database Hostname
+                type: string
+              hash:
+                additionalProperties:
+                  type: string
+                description: Map of hashes to track e.g. job status
+                type: object
+              healthmanagerreadyCount:
+                description: ReadyCount of octavia HealthManager instances
+                format: int32
+                type: integer
+              housekeepingreadyCount:
+                description: ReadyCount of octavia Housekeeping instances
+                format: int32
+                type: integer
+              serviceID:
+                description: ServiceID - the ID of the registered service in keystone
+                type: string
+              workerreadyCount:
+                description: ReadyCount of octavia Worker instances
+                format: int32
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/api/bases/octavia.openstack.org_octaviaapis.yaml
+++ b/api/bases/octavia.openstack.org_octaviaapis.yaml
@@ -1,0 +1,262 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.10.0
+  creationTimestamp: null
+  name: octaviaapis.octavia.openstack.org
+spec:
+  group: octavia.openstack.org
+  names:
+    kind: OctaviaAPI
+    listKind: OctaviaAPIList
+    plural: octaviaapis
+    singular: octaviaapi
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Status
+      jsonPath: .status.conditions[0].status
+      name: Status
+      type: string
+    - description: Message
+      jsonPath: .status.conditions[0].message
+      name: Message
+      type: string
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: OctaviaAPI is the Schema for the octaviaapis API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: OctaviaAPISpec defines the desired state of OctaviaAPI
+            properties:
+              containerImage:
+                description: Octavia Container Image URL
+                type: string
+              customServiceConfig:
+                default: '# add your customization here'
+                description: CustomServiceConfig - customize the service config using
+                  this parameter to change service defaults, or overwrite rendered
+                  information using raw OpenStack config format. The content gets
+                  added to to /etc/<service>/<service>.conf.d directory as custom.conf
+                  file.
+                type: string
+              databaseHostname:
+                description: DatabaseHostname - Octavia DB hostname
+                type: string
+              databaseInstance:
+                description: MariaDB instance name Right now required by the maridb-operator
+                  to get the credentials from the instance to create the DB Might
+                  not be required in future
+                type: string
+              databaseUser:
+                default: octavia
+                description: 'DatabaseUser - optional username used for octavia DB,
+                  defaults to octavia TODO: -> implement needs work in mariadb-operator,
+                  right now only octavia'
+                type: string
+              debug:
+                description: Debug - enable debug for different deploy stages. If
+                  an init container is used, it runs and the actual action pod gets
+                  started with sleep infinity
+                properties:
+                  dbSync:
+                    default: false
+                    description: DBSync enable debug
+                    type: boolean
+                  service:
+                    default: false
+                    description: Service enable debug
+                    type: boolean
+                type: object
+              defaultConfigOverwrite:
+                additionalProperties:
+                  type: string
+                description: 'ConfigOverwrite - interface to overwrite default config
+                  files like e.g. logging.conf or policy.json. But can also be used
+                  to add additional files. Those get added to the service config dir
+                  in /etc/<service> . TODO: -> implement'
+                type: object
+              nodeSelector:
+                additionalProperties:
+                  type: string
+                description: NodeSelector to target subset of worker nodes running
+                  this service
+                type: object
+              passwordSelectors:
+                default:
+                  database: OctaviaDatabasePassword
+                  service: OctaviaPassword
+                description: PasswordSelectors - Selectors to identify the DB and
+                  ServiceUser password from the Secret
+                properties:
+                  database:
+                    default: OctaviaDatabasePassword
+                    description: 'Database - Selector to get the octavia Database
+                      user password from the Secret TODO: not used, need change in
+                      mariadb-operator'
+                    type: string
+                  service:
+                    default: OctaviaPassword
+                    description: Service - Selector to get the service user password
+                      from the Secret
+                    type: string
+                type: object
+              preserveJobs:
+                default: false
+                description: PreserveJobs - do not delete jobs after they finished
+                  e.g. to check logs
+                type: boolean
+              replicas:
+                default: 1
+                description: Replicas of octavia API to run
+                format: int32
+                maximum: 32
+                minimum: 0
+                type: integer
+              resources:
+                description: Resources - Compute Resources required by this service
+                  (Limits/Requests). https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                properties:
+                  claims:
+                    description: "Claims lists the names of resources, defined in
+                      spec.resourceClaims, that are used by this container. \n This
+                      is an alpha field and requires enabling the DynamicResourceAllocation
+                      feature gate. \n This field is immutable."
+                    items:
+                      description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                      properties:
+                        name:
+                          description: Name must match the name of one entry in pod.spec.resourceClaims
+                            of the Pod where this field is used. It makes that resource
+                            available inside a container.
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    type: array
+                    x-kubernetes-list-map-keys:
+                    - name
+                    x-kubernetes-list-type: map
+                  limits:
+                    additionalProperties:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    description: 'Limits describes the maximum amount of compute resources
+                      allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                    type: object
+                  requests:
+                    additionalProperties:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    description: 'Requests describes the minimum amount of compute
+                      resources required. If Requests is omitted for a container,
+                      it defaults to Limits if that is explicitly specified, otherwise
+                      to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                    type: object
+                type: object
+              secret:
+                description: Secret containing OpenStack password information for
+                  octavia OctaviaDatabasePassword, AdminPassword
+                type: string
+              serviceUser:
+                default: octavia
+                description: ServiceUser - service user name
+                type: string
+            required:
+            - containerImage
+            - databaseInstance
+            - secret
+            type: object
+          status:
+            description: OctaviaAPIStatus defines the observed state of OctaviaAPI
+            properties:
+              apiEndpoint:
+                additionalProperties:
+                  type: string
+                description: API endpoint
+                type: object
+              conditions:
+                description: Conditions
+                items:
+                  description: Condition defines an observation of a API resource
+                    operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another. This should be when the underlying condition changed.
+                        If that is not known, then using the time when the API field
+                        changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition
+                        in CamelCase.
+                      type: string
+                    severity:
+                      description: Severity provides a classification of Reason code,
+                        so the current situation is immediately understandable and
+                        could act accordingly. It is meant for situations where Status=False
+                        and it should be indicated if it is just informational, warning
+                        (next reconciliation might fix it) or an error (e.g. DB create
+                        issue and no actions to automatically resolve the issue can/should
+                        be done). For conditions where Status=Unknown or Status=True
+                        the Severity should be SeverityNone.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of condition in CamelCase.
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - status
+                  - type
+                  type: object
+                type: array
+              databaseHostname:
+                description: Octavia Database Hostname
+                type: string
+              hash:
+                additionalProperties:
+                  type: string
+                description: Map of hashes to track e.g. job status
+                type: object
+              readyCount:
+                description: ReadyCount of octavia API instances
+                format: int32
+                type: integer
+              serviceID:
+                description: ServiceID - the ID of the registered service in keystone
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}


### PR DESCRIPTION
With the new api sub module, consumer operators just have to import the api submodule. For envtest it is required to install CRD for e.g. keystone-operator and mariadb-operator to be able to use it.

Moving the directory config/crd/bases which holds the generated files in to the api module that they are available with the module and link the dir in the original place does not work as kustomize autodetect fails on symlinked directories [1].

This updates the `generate` Makefile target to copy config/crd/bases to /api on successful generation run.

[1] kubernetes-sigs/kustomize#1886