### PR TITLE
Replace TripleO images by TCIB images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -307,7 +307,7 @@ operator-lint: gowork ## Runs operator-lint
 # $oc delete -n openstack mutatingwebhookconfiguration/moctavia.kb.io
 SKIP_CERT ?=false
 .PHONY: run-with-webhook
-run-with-webhook: export OCTAVIA_API_IMAGE_URL_DEFAULT=quay.io/tripleozedcentos9/openstack-octavia-api:current-tripleo
+run-with-webhook: export OCTAVIA_API_IMAGE_URL_DEFAULT=quay.io/podified-antelope-centos9/openstack-octavia-api:current-podified
 run-with-webhook: manifests generate fmt vet ## Run a controller from your host.
 	/bin/bash hack/configure_local_webhook.sh
 	go run ./main.go

--- a/config/default/manager_default_images.yaml
+++ b/config/default/manager_default_images.yaml
@@ -12,4 +12,4 @@ spec:
       - name: manager
         env:
         - name: OCTAVIA_API_IMAGE_URL_DEFAULT
-          value: quay.io/tripleozedcentos9/openstack-octavia-api:current-tripleo
+          value: quay.io/podified-antelope-centos9/openstack-octavia-api:current-podified

--- a/config/samples/octavia_v1beta1_octavia.yaml
+++ b/config/samples/octavia_v1beta1_octavia.yaml
@@ -22,7 +22,7 @@ spec:
     databaseInstance: openstack
     databaseUser: octavia
     serviceUser: octavia
-    containerImage: quay.io/tripleozedcentos9/openstack-octavia-api:current-tripleo
+    containerImage: quay.io/podified-antelope-centos9/openstack-octavia-api:current-podified
     replicas: 1
     secret: osp-secret
     # passwordSelectors: TODO

--- a/tests/kuttl/common/assert_sample_deployment.yaml
+++ b/tests/kuttl/common/assert_sample_deployment.yaml
@@ -33,7 +33,7 @@ spec:
   secret: osp-secret
   serviceUser: octavia
   octaviaAPI:
-    containerImage: quay.io/tripleozedcentos9/openstack-octavia-api:current-tripleo
+    containerImage: quay.io/podified-antelope-centos9/openstack-octavia-api:current-podified
     customServiceConfig: |
       [DEFAULT]
       debug = true
@@ -83,7 +83,7 @@ spec:
         - /usr/local/bin/kolla_set_configs && /usr/local/bin/kolla_start
         command:
         - /bin/bash
-        image: quay.io/tripleozedcentos9/openstack-octavia-api:current-tripleo
+        image: quay.io/podified-antelope-centos9/openstack-octavia-api:current-podified
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3
@@ -110,7 +110,7 @@ spec:
         - name: CONFIG_HASH
         - name: KOLLA_CONFIG_FILE
         - name: KOLLA_CONFIG_STRATEGY
-        image: quay.io/tripleozedcentos9/openstack-octavia-api:current-tripleo
+        image: quay.io/podified-antelope-centos9/openstack-octavia-api:current-podified
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3
@@ -156,7 +156,7 @@ spec:
           value: octavia
         - name: DatabaseUser
           value: octavia
-        image: quay.io/tripleozedcentos9/openstack-octavia-api:current-tripleo
+        image: quay.io/podified-antelope-centos9/openstack-octavia-api:current-podified
         imagePullPolicy: IfNotPresent
         name: init
         resources: {}


### PR DESCRIPTION
We imported container build tools from TripleO as TCIB[1]. Now we are retiring TripleO and should complete the migration.

[1] https://github.com/openstack-k8s-operators/tcib