### PR TITLE
Stop creating admin endpoint

### DIFF
--- a/controllers/octaviaapi_controller.go
+++ b/controllers/octaviaapi_controller.go
@@ -242,9 +242,6 @@ func (r *OctaviaAPIReconciler) reconcileInit(
 	// expose the service (create service, route and return the created endpoint URLs)
 	//
 	var octaviaPorts = map[endpoint.Endpoint]endpoint.Data{
-		endpoint.EndpointAdmin: {
-			Port: octavia.OctaviaAdminPort,
-		},
 		endpoint.EndpointPublic: {
 			Port: octavia.OctaviaPublicPort,
 		},

--- a/pkg/octavia/const.go
+++ b/pkg/octavia/const.go
@@ -25,8 +25,6 @@ const (
 	// DatabaseName -
 	DatabaseName = "octavia"
 
-	// OctaviaAdminPort -
-	OctaviaAdminPort int32 = 9876
 	// OctaviaPublicPort -
 	OctaviaPublicPort int32 = 9876
 	// OctaviaInternalPort -


### PR DESCRIPTION
keystone-operator no longer creates admin endpoint[1]. This follows that and removing admin endpoint.

[1] openstack-k8s-operators/keystone-operator#175