### PR TITLE
Fix config map processing of conf files

### DIFF
--- a/templates/octavia/config/octavia.conf
+++ b/templates/octavia/config/octavia.conf
@@ -1,7 +1,5 @@
 [DEFAULT]
 debug=True
-# debug={{.Debug}}
-# transport_url={{.RabbitTransportURL}}
 rpc_response_timeout=60
 log_file=/var/log/octavia/octavia.log
 log_dir=/var/log/octavia
@@ -61,7 +59,6 @@ amp_boot_network_list=
 client_ca=/etc/octavia/certs/ca_01.pem
 [task_flow]
 [oslo_messaging]
-# transport_url={{.RabbitTransportURL}}
 # topic=octavia-rpc
 [oslo_middleware]
 # enable_proxy_headers_parsing=True
@@ -81,7 +78,6 @@ disable_local_log_storage=False
 # password=FIXMEpw3
 # username=octavia
 # auth_type=password
-# auth_url={{ .KeystonePublicURL }}/v3
 # region_name=regionOne
 [nova]
 # region_name=regionOne
@@ -99,12 +95,5 @@ disable_local_log_storage=False
 [audit]
 [audit_middleware_notifications]
 [oslo_messaging_notifications]
-# driver=noop
-# [driver_agent]
-# enabled_provider_agents=ovn
-# [healthcheck]
-# [ovn]
-# ovn_nb_connection={{ .NBConnection }}
-# ovn_sb_connection={{ .SBConnection }}
 [oslo_policy]
 # policy_file=/etc/octavia/policy.yaml

--- a/templates/octaviaapi/config/octavia.conf
+++ b/templates/octaviaapi/config/octavia.conf
@@ -1,7 +1,5 @@
 [DEFAULT]
 debug=True
-# debug={{.Debug}}
-# transport_url={{.RabbitTransportURL}}
 rpc_response_timeout=60
 log_file=/var/log/octavia/octavia.log
 log_dir=/var/log/octavia
@@ -61,7 +59,6 @@ amp_boot_network_list=
 client_ca=/etc/octavia/certs/ca_01.pem
 [task_flow]
 [oslo_messaging]
-# transport_url={{.RabbitTransportURL}}
 # topic=octavia-rpc
 [oslo_middleware]
 # enable_proxy_headers_parsing=True


### PR DESCRIPTION
Some of the config files had commented out sections that included references to parameters that weren't yet valid, namely .Debug and .RabbitTransportURL. This has been breaking the reconcile loop for awhile.