### PR TITLE
Remove endpoint url and keystone service id from status

### DIFF
--- a/api/bases/octavia.openstack.org_octaviaapis.yaml
+++ b/api/bases/octavia.openstack.org_octaviaapis.yaml
@@ -197,11 +197,6 @@ spec:
           status:
             description: OctaviaAPIStatus defines the observed state of OctaviaAPI
             properties:
-              apiEndpoints:
-                additionalProperties:
-                  type: string
-                description: API endpoint
-                type: object
               conditions:
                 description: Conditions
                 items:
@@ -257,9 +252,6 @@ spec:
                 description: ReadyCount of octavia API instances
                 format: int32
                 type: integer
-              serviceID:
-                description: ServiceID - the ID of the registered service in keystone
-                type: string
             type: object
         type: object
     served: true

--- a/api/bases/octavia.openstack.org_octavias.yaml
+++ b/api/bases/octavia.openstack.org_octavias.yaml
@@ -286,11 +286,6 @@ spec:
           status:
             description: OctaviaStatus defines the observed state of Octavia
             properties:
-              apiEndpoints:
-                additionalProperties:
-                  type: string
-                description: API endpoint
-                type: object
               apireadyCount:
                 description: ReadyCount of octavia API instances
                 format: int32
@@ -354,9 +349,6 @@ spec:
                 description: ReadyCount of octavia Housekeeping instances
                 format: int32
                 type: integer
-              serviceID:
-                description: ServiceID - the ID of the registered service in keystone
-                type: string
               workerreadyCount:
                 description: ReadyCount of octavia Worker instances
                 format: int32

--- a/api/go.mod
+++ b/api/go.mod
@@ -42,7 +42,6 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
-	github.com/openshift/api v3.9.0+incompatible // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/prometheus/client_golang v1.14.0 // indirect
 	github.com/prometheus/client_model v0.3.0 // indirect

--- a/api/go.sum
+++ b/api/go.sum
@@ -229,8 +229,6 @@ github.com/onsi/ginkgo/v2 v2.11.0 h1:WgqUCUt/lT6yXoQ8Wef0fsNn5cAuMK7+KT9UFRz2tcU
 github.com/onsi/ginkgo/v2 v2.11.0/go.mod h1:ZhrRA5XmEE3x3rhlzamx/JJvujdZoJ2uvgI7kR0iZvM=
 github.com/onsi/gomega v1.27.8 h1:gegWiwZjBsf2DgiSbf5hpokZ98JVDMcWkUiigk6/KXc=
 github.com/onsi/gomega v1.27.8/go.mod h1:2J8vzI/s+2shY9XHRApDkdgPo1TKT7P2u6fXeJKFnNQ=
-github.com/openshift/api v0.0.0-20230414143018-3367bc7e6ac7 h1:rncLxJBpFGqBztyxCMwNRnMjhhIDOWHJowi6q8G6koI=
-github.com/openshift/api v0.0.0-20230414143018-3367bc7e6ac7/go.mod h1:ctXNyWanKEjGj8sss1KjjHQ3ENKFm33FFnS5BKaIPh4=
 github.com/openstack-k8s-operators/lib-common/modules/common v0.0.0-20230523062001-d41eddbb4da6 h1:saDJELginwknzS9wW4AhDSIBg25+hEDf1tIjjXKTeC8=
 github.com/openstack-k8s-operators/lib-common/modules/common v0.0.0-20230523062001-d41eddbb4da6/go.mod h1:r8cMUoS+gnBTrGbmLLECafzhZBh6P9rMwgnrGVspbqE=
 github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsKMEsNbx1VGcRFpLqf3715MtcvvzbA=

--- a/api/v1beta1/octavia_types.go
+++ b/api/v1beta1/octavia_types.go
@@ -17,10 +17,7 @@ limitations under the License.
 package v1beta1
 
 import (
-	"fmt"
-
 	"github.com/openstack-k8s-operators/lib-common/modules/common/condition"
-	"github.com/openstack-k8s-operators/lib-common/modules/common/endpoint"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/util"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -114,17 +111,11 @@ type OctaviaStatus struct {
 	// Map of hashes to track e.g. job status
 	Hash map[string]string `json:"hash,omitempty"`
 
-	// API endpoint
-	APIEndpoints map[string]string `json:"apiEndpoints,omitempty"`
-
 	// Conditions
 	Conditions condition.Conditions `json:"conditions,omitempty" optional:"true"`
 
 	// Octavia Database Hostname
 	DatabaseHostname string `json:"databaseHostname,omitempty"`
-
-	// ServiceID - the ID of the registered service in keystone
-	ServiceID string `json:"serviceID,omitempty"`
 
 	// ReadyCount of octavia API instances
 	OctaviaAPIReadyCount int32 `json:"apireadyCount,omitempty"`
@@ -165,14 +156,6 @@ type OctaviaList struct {
 
 func init() {
 	SchemeBuilder.Register(&Octavia{}, &OctaviaList{})
-}
-
-// GetEndpoint - returns OpenStack endpoint url for type
-func (instance Octavia) GetEndpoint(endpointType endpoint.Endpoint) (string, error) {
-	if url, found := instance.Status.APIEndpoints[string(endpointType)]; found {
-		return url, nil
-	}
-	return "", fmt.Errorf("%s endpoint not found", string(endpointType))
 }
 
 // IsReady - returns true if service is ready to server requests

--- a/api/v1beta1/octaviaapi_types.go
+++ b/api/v1beta1/octaviaapi_types.go
@@ -17,10 +17,7 @@ limitations under the License.
 package v1beta1
 
 import (
-	"fmt"
-
 	"github.com/openstack-k8s-operators/lib-common/modules/common/condition"
-	"github.com/openstack-k8s-operators/lib-common/modules/common/endpoint"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -139,17 +136,11 @@ type OctaviaAPIStatus struct {
 	// Map of hashes to track e.g. job status
 	Hash map[string]string `json:"hash,omitempty"`
 
-	// API endpoint
-	APIEndpoints map[string]string `json:"apiEndpoints,omitempty"`
-
 	// Conditions
 	Conditions condition.Conditions `json:"conditions,omitempty" optional:"true"`
 
 	// Octavia Database Hostname
 	DatabaseHostname string `json:"databaseHostname,omitempty"`
-
-	// ServiceID - the ID of the registered service in keystone
-	ServiceID string `json:"serviceID,omitempty"`
 }
 
 //+kubebuilder:object:root=true
@@ -177,14 +168,6 @@ type OctaviaAPIList struct {
 
 func init() {
 	SchemeBuilder.Register(&OctaviaAPI{}, &OctaviaAPIList{})
-}
-
-// GetEndpoint - returns OpenStack endpoint url for type
-func (instance OctaviaAPI) GetEndpoint(endpointType endpoint.Endpoint) (string, error) {
-	if url, found := instance.Status.APIEndpoints[string(endpointType)]; found {
-		return url, nil
-	}
-	return "", fmt.Errorf("%s endpoint not found", string(endpointType))
 }
 
 // IsReady - returns true if service is ready to server requests

--- a/api/v1beta1/zz_generated.deepcopy.go
+++ b/api/v1beta1/zz_generated.deepcopy.go
@@ -174,13 +174,6 @@ func (in *OctaviaAPIStatus) DeepCopyInto(out *OctaviaAPIStatus) {
 			(*out)[key] = val
 		}
 	}
-	if in.APIEndpoints != nil {
-		in, out := &in.APIEndpoints, &out.APIEndpoints
-		*out = make(map[string]string, len(*in))
-		for key, val := range *in {
-			(*out)[key] = val
-		}
-	}
 	if in.Conditions != nil {
 		in, out := &in.Conditions, &out.Conditions
 		*out = make(condition.Conditions, len(*in))
@@ -284,13 +277,6 @@ func (in *OctaviaStatus) DeepCopyInto(out *OctaviaStatus) {
 	*out = *in
 	if in.Hash != nil {
 		in, out := &in.Hash, &out.Hash
-		*out = make(map[string]string, len(*in))
-		for key, val := range *in {
-			(*out)[key] = val
-		}
-	}
-	if in.APIEndpoints != nil {
-		in, out := &in.APIEndpoints, &out.APIEndpoints
 		*out = make(map[string]string, len(*in))
 		for key, val := range *in {
 			(*out)[key] = val

--- a/config/crd/bases/octavia.openstack.org_octaviaapis.yaml
+++ b/config/crd/bases/octavia.openstack.org_octaviaapis.yaml
@@ -197,11 +197,6 @@ spec:
           status:
             description: OctaviaAPIStatus defines the observed state of OctaviaAPI
             properties:
-              apiEndpoints:
-                additionalProperties:
-                  type: string
-                description: API endpoint
-                type: object
               conditions:
                 description: Conditions
                 items:
@@ -257,9 +252,6 @@ spec:
                 description: ReadyCount of octavia API instances
                 format: int32
                 type: integer
-              serviceID:
-                description: ServiceID - the ID of the registered service in keystone
-                type: string
             type: object
         type: object
     served: true

--- a/config/crd/bases/octavia.openstack.org_octavias.yaml
+++ b/config/crd/bases/octavia.openstack.org_octavias.yaml
@@ -286,11 +286,6 @@ spec:
           status:
             description: OctaviaStatus defines the observed state of Octavia
             properties:
-              apiEndpoints:
-                additionalProperties:
-                  type: string
-                description: API endpoint
-                type: object
               apireadyCount:
                 description: ReadyCount of octavia API instances
                 format: int32
@@ -354,9 +349,6 @@ spec:
                 description: ReadyCount of octavia Housekeeping instances
                 format: int32
                 type: integer
-              serviceID:
-                description: ServiceID - the ID of the registered service in keystone
-                type: string
               workerreadyCount:
                 description: ReadyCount of octavia Worker instances
                 format: int32

--- a/controllers/octavia_controller.go
+++ b/controllers/octavia_controller.go
@@ -163,9 +163,6 @@ func (r *OctaviaReconciler) Reconcile(ctx context.Context, req ctrl.Request) (re
 	if instance.Status.Hash == nil {
 		instance.Status.Hash = map[string]string{}
 	}
-	if instance.Status.APIEndpoints == nil {
-		instance.Status.APIEndpoints = map[string]string{}
-	}
 
 	// Handle service delete
 	if !instance.DeletionTimestamp.IsZero() {
@@ -484,11 +481,9 @@ func (r *OctaviaReconciler) reconcileNormal(ctx context.Context, instance *octav
 		r.Log.Info(fmt.Sprintf("Deployment %s successfully reconciled - operation: %s", instance.Name, string(op)))
 	}
 
-	// Mirror CinderAPI status' APIEndpoints and ReadyCount to this parent CR
+	// Mirror OctaviaAPI status' ReadyCount to this parent CR
 	// TODO(beagles): We need to have a way to aggregate conditions from the other services into this
 	//
-	instance.Status.APIEndpoints = octaviaAPI.Status.APIEndpoints
-	instance.Status.ServiceID = octaviaAPI.Status.ServiceID
 	instance.Status.OctaviaAPIReadyCount = octaviaAPI.Status.ReadyCount
 	conditionStatus := octaviaAPI.Status.Conditions.Mirror(condition.ReadyCondition)
 	if conditionStatus != nil {

--- a/tests/kuttl/common/assert_sample_deployment.yaml
+++ b/tests/kuttl/common/assert_sample_deployment.yaml
@@ -221,9 +221,8 @@ apiVersion: kuttl.dev/v1beta1
 kind: TestAssert
 commands:
   - script: |
-      template='{{.status.apiEndpoints.public}}{{"\n"}}'
-      regex="http:\/\/octavia-public-$NAMESPACE\.apps.*"
-      apiEndpoints=$(oc get -n $NAMESPACE octavia octavia -o go-template="$template")
+      regex="octavia-public-${NAMESPACE}\.apps.*"
+      apiEndpoints=$(oc get route -n $NAMESPACE octavia-public -o jsonpath='{.status.ingress[0].host}')
       matches=$(echo $apiEndpoints | sed -e "s?$regex??")
       if [ -z "$matches" ]; then
         exit 0


### PR DESCRIPTION
These items presented in CR status are not really used. Endpoints can be discovered using Keystone and we have no use case to require service id.

This also removes a separate registerInKeystone function to make the code structure more consistent with the other operators.