### PR TITLE
Change kuttl test to run in any namespace

### DIFF
--- a/kuttl-test.yaml
+++ b/kuttl-test.yaml
@@ -16,9 +16,9 @@
 
 apiVersion: kuttl.dev/v1beta1
 kind: TestSuite
+namespace: octavia-kuttl-tests
 reportFormat: JSON
 reportName: kuttl-test-octavia
-namespace: openstack
 timeout: 180
 parallel: 1
 suppress:

--- a/tests/kuttl/common/assert_sample_deployment.yaml
+++ b/tests/kuttl/common/assert_sample_deployment.yaml
@@ -14,7 +14,6 @@ metadata:
   finalizers:
   - Octavia
   name: octavia
-  namespace: openstack
 spec:
   customServiceConfig: |
     [DEFAULT]
@@ -55,7 +54,6 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: octavia-api
-  namespace: openstack
 spec:
   replicas: 1
   template:
@@ -181,7 +179,6 @@ metadata:
     internal: "true"
     service: octavia
   name: octavia-internal
-  namespace: openstack
 spec:
   ports:
     - name: octavia-internal
@@ -196,7 +193,6 @@ metadata:
     public: "true"
     service: octavia
   name: octavia-public
-  namespace: openstack
 spec:
   ports:
     - name: octavia-public
@@ -211,7 +207,6 @@ metadata:
   labels:
     public: "true"
     service: octavia
-  namespace: openstack
 spec:
   port:
     targetPort: octavia-public
@@ -224,12 +219,11 @@ spec:
 # the three endpoints are defined and their addresses follow the default pattern
 apiVersion: kuttl.dev/v1beta1
 kind: TestAssert
-namespaced: true
 commands:
   - script: |
       template='{{.status.apiEndpoints.public}}{{"\n"}}'
-      regex="http:\/\/octavia-public-openstack\.apps.*"
-      apiEndpoints=$(oc get -n openstack octavia octavia -o go-template="$template")
+      regex="http:\/\/octavia-public-$NAMESPACE\.apps.*"
+      apiEndpoints=$(oc get -n $NAMESPACE octavia octavia -o go-template="$template")
       matches=$(echo $apiEndpoints | sed -e "s?$regex??")
       if [ -z "$matches" ]; then
         exit 0

--- a/tests/kuttl/tests/octavia_scale/02-assert.yaml
+++ b/tests/kuttl/tests/octavia_scale/02-assert.yaml
@@ -11,7 +11,6 @@ metadata:
   finalizers:
   - Octavia
   name: octavia
-  namespace: openstack
 spec:
   octaviaAPI:
     replicas: 3

--- a/tests/kuttl/tests/octavia_scale/02-scale-octaviaapi.yaml
+++ b/tests/kuttl/tests/octavia_scale/02-scale-octaviaapi.yaml
@@ -2,4 +2,4 @@ apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 commands:
   - script: |
-      oc patch octavia -n openstack octavia --type='json' -p='[{"op": "replace", "path": "/spec/octaviaAPI/replicas", "value":3}]'
+      oc patch octavia -n $NAMESPACE octavia --type='json' -p='[{"op": "replace", "path": "/spec/octaviaAPI/replicas", "value":3}]'

--- a/tests/kuttl/tests/octavia_scale/03-assert.yaml
+++ b/tests/kuttl/tests/octavia_scale/03-assert.yaml
@@ -11,7 +11,6 @@ metadata:
   finalizers:
   - Octavia
   name: octavia
-  namespace: openstack
 spec:
   octaviaAPI:
     replicas: 1
@@ -22,7 +21,6 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: octavia-api
-  namespace: openstack
 spec:
   replicas: 1
 status:

--- a/tests/kuttl/tests/octavia_scale/03-scale-down-octaviaapi.yaml
+++ b/tests/kuttl/tests/octavia_scale/03-scale-down-octaviaapi.yaml
@@ -2,4 +2,4 @@ apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 commands:
   - script: |
-      oc patch octavia -n openstack octavia --type='json' -p='[{"op": "replace", "path": "/spec/octaviaAPI/replicas", "value":1}]'
+      oc patch octavia -n $NAMESPACE octavia --type='json' -p='[{"op": "replace", "path": "/spec/octaviaAPI/replicas", "value":1}]'

--- a/tests/kuttl/tests/octavia_scale/04-assert.yaml
+++ b/tests/kuttl/tests/octavia_scale/04-assert.yaml
@@ -11,7 +11,6 @@ metadata:
   finalizers:
   - Octavia
   name: octavia
-  namespace: openstack
 spec:
   octaviaAPI:
     replicas: 0

--- a/tests/kuttl/tests/octavia_scale/04-scale-down-zero-octaviaapi.yaml
+++ b/tests/kuttl/tests/octavia_scale/04-scale-down-zero-octaviaapi.yaml
@@ -2,4 +2,4 @@ apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 commands:
   - script: |
-      oc patch octavia -n openstack octavia --type='json' -p='[{"op": "replace", "path": "/spec/octaviaAPI/replicas", "value":0}]'
+      oc patch octavia -n $NAMESPACE octavia --type='json' -p='[{"op": "replace", "path": "/spec/octaviaAPI/replicas", "value":0}]'

--- a/tests/kuttl/tests/octavia_scale/05-cleanup-octavia.yaml
+++ b/tests/kuttl/tests/octavia_scale/05-cleanup-octavia.yaml
@@ -4,4 +4,3 @@ delete:
 - apiVersion: octavia.openstack.org/v1beta1
   kind: Octavia
   name: octavia
-  namespace: openstack

--- a/tests/kuttl/tests/octavia_scale/05-errors.yaml
+++ b/tests/kuttl/tests/octavia_scale/05-errors.yaml
@@ -13,13 +13,11 @@ metadata:
   finalizers:
   - Octavia
   name: octavia
-  namespace: openstack
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: octavia-api
-  namespace: openstack
 ---
 # the openshift annotations can't be checked through the deployment above
 apiVersion: v1
@@ -37,7 +35,6 @@ metadata:
     internal: "true"
     service: octavia
   name: octavia-internal
-  namespace: openstack
 spec:
   ports:
     - name: octavia-internal
@@ -52,7 +49,6 @@ metadata:
     public: "true"
     service: octavia
   name: octavia-public
-  namespace: openstack
 spec:
   ports:
     - name: octavia-public
@@ -67,7 +63,6 @@ metadata:
   labels:
     public: "true"
     service: octavia
-  namespace: openstack
 spec:
   port:
     targetPort: octavia-public


### PR DESCRIPTION
Modify the kuttl tests so that they can run in any namespace, not just
in the openstack one. This requires removing any mention of the
namespace in the asserts and using the $NAMESPACE variable in scripts
instead of the namespace name.

Needs https://github.com/openstack-k8s-operators/install_yamls/pull/465 to be
merged for CI to pass.
