### PR TITLE
switch to structured logging

### DIFF
--- a/main.go
+++ b/main.go
@@ -17,6 +17,7 @@ limitations under the License.
 package main
 
 import (
+	"context"
 	"crypto/tls"
 	"flag"
 	"os"
@@ -139,8 +140,7 @@ func main() {
 		Client:  mgr.GetClient(),
 		Scheme:  mgr.GetScheme(),
 		Kclient: kclient,
-		Log:     ctrl.Log.WithName("controllers").WithName("OctaviaAPI"),
-	}).SetupWithManager(mgr); err != nil {
+	}).SetupWithManager(context.Background(), mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "OctaviaAPI")
 		os.Exit(1)
 	}
@@ -149,7 +149,6 @@ func main() {
 		Client:  mgr.GetClient(),
 		Scheme:  mgr.GetScheme(),
 		Kclient: kclient,
-		Log:     ctrl.Log.WithName("controllers").WithName("Octavia"),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Octavia")
 		os.Exit(1)


### PR DESCRIPTION
This automatically adds additional fields like reconcile_id etc.. from the controller context.

before :

`2023-05-18T01:53:14+03:00 INFO  controllers.KeystoneAPI Reconciled Service init successfully`

after:

`2023-10-19T12:34:21.071+0300    INFO    Controllers.Octavia     Reconciling Service init        {"controller": "octavia", "controllerGroup": "octavia.openstack.org", "controllerKind": "Octavia", "Octavia": {"name":"octavia","namespace":"openstack"}, "namespace": "openst
ack", "name": "octavia", "reconcileID": "aa9cbe69-f198-40b6-be55-451b489ac9d2"}   
`

*by using per reconcile function respective logger objects, the intention is to lay the ground for parallel reconciliation in future and avoid race conditions as ctx objects are reconcile run specific.



