### PR TITLE
Fix missing transport URL config

### DIFF
--- a/api/bases/octavia.openstack.org_octaviaapis.yaml
+++ b/api/bases/octavia.openstack.org_octaviaapis.yaml
@@ -372,6 +372,9 @@ spec:
                 default: octavia
                 description: ServiceUser - service user name
                 type: string
+              transportURLSecret:
+                description: TransportURLSecret - Secret containing RabbitMQ transportURL
+                type: string
             required:
             - containerImage
             - databaseInstance

--- a/api/bases/octavia.openstack.org_octavias.yaml
+++ b/api/bases/octavia.openstack.org_octavias.yaml
@@ -428,6 +428,9 @@ spec:
                     default: octavia
                     description: ServiceUser - service user name
                     type: string
+                  transportURLSecret:
+                    description: TransportURLSecret - Secret containing RabbitMQ transportURL
+                    type: string
                 required:
                 - containerImage
                 - databaseInstance

--- a/api/v1beta1/octaviaapi_types.go
+++ b/api/v1beta1/octaviaapi_types.go
@@ -111,6 +111,10 @@ type OctaviaAPISpec struct {
 	DefaultConfigOverwrite map[string]string `json:"defaultConfigOverwrite,omitempty"`
 
 	// +kubebuilder:validation:Optional
+	// TransportURLSecret - Secret containing RabbitMQ transportURL
+	TransportURLSecret string `json:"transportURLSecret,omitempty"`
+
+	// +kubebuilder:validation:Optional
 	// Resources - Compute Resources required by this service (Limits/Requests).
 	// https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
 	Resources corev1.ResourceRequirements `json:"resources,omitempty"`

--- a/config/crd/bases/octavia.openstack.org_octaviaapis.yaml
+++ b/config/crd/bases/octavia.openstack.org_octaviaapis.yaml
@@ -372,6 +372,9 @@ spec:
                 default: octavia
                 description: ServiceUser - service user name
                 type: string
+              transportURLSecret:
+                description: TransportURLSecret - Secret containing RabbitMQ transportURL
+                type: string
             required:
             - containerImage
             - databaseInstance

--- a/config/crd/bases/octavia.openstack.org_octavias.yaml
+++ b/config/crd/bases/octavia.openstack.org_octavias.yaml
@@ -428,6 +428,9 @@ spec:
                     default: octavia
                     description: ServiceUser - service user name
                     type: string
+                  transportURLSecret:
+                    description: TransportURLSecret - Secret containing RabbitMQ transportURL
+                    type: string
                 required:
                 - containerImage
                 - databaseInstance

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -273,6 +273,15 @@ rules:
   - security.openshift.io
   resourceNames:
   - anyuid
+  - hostmount-anyuid
+  resources:
+  - securitycontextconstraints
+  verbs:
+  - use
+- apiGroups:
+  - security.openshift.io
+  resourceNames:
+  - anyuid
   - privileged
   resources:
   - securitycontextconstraints

--- a/controllers/octavia_controller.go
+++ b/controllers/octavia_controller.go
@@ -749,6 +749,7 @@ func (r *OctaviaReconciler) apiDeploymentCreateOrUpdate(instance *octaviav1.Octa
 		deployment.Spec.DatabaseHostname = instance.Status.DatabaseHostname
 		deployment.Spec.DatabaseUser = instance.Spec.DatabaseUser
 		deployment.Spec.ServiceUser = instance.Spec.ServiceUser
+		deployment.Spec.TransportURLSecret = instance.Status.TransportURLSecret
 		deployment.Spec.Secret = instance.Spec.Secret
 		deployment.Spec.ServiceAccount = instance.RbacResourceName()
 		if len(deployment.Spec.NodeSelector) == 0 {

--- a/pkg/amphoracontrollers/deployment.go
+++ b/pkg/amphoracontrollers/deployment.go
@@ -131,6 +131,7 @@ func Deployment(
 		DatabaseUser:         instance.Spec.DatabaseUser,
 		DatabaseName:         octavia.DatabaseName,
 		OSPSecret:            instance.Spec.Secret,
+		TransportURLSecret:   instance.Spec.TransportURLSecret,
 		DBPasswordSelector:   instance.Spec.PasswordSelectors.Database,
 		UserPasswordSelector: instance.Spec.PasswordSelectors.Service,
 		VolumeMounts:         octavia.GetInitVolumeMounts(),

--- a/pkg/octaviaapi/deployment.go
+++ b/pkg/octaviaapi/deployment.go
@@ -168,6 +168,7 @@ func Deployment(
 		DatabaseUser:         instance.Spec.DatabaseUser,
 		DatabaseName:         octavia.DatabaseName,
 		OSPSecret:            instance.Spec.Secret,
+		TransportURLSecret:   instance.Spec.TransportURLSecret,
 		DBPasswordSelector:   instance.Spec.PasswordSelectors.Database,
 		UserPasswordSelector: instance.Spec.PasswordSelectors.Service,
 		VolumeMounts:         initVolumeMounts,

--- a/templates/octavia/bin/init.sh
+++ b/templates/octavia/bin/init.sh
@@ -42,10 +42,8 @@ for dir in /var/lib/config-data/default; do
 done
 
 # set secrets
-
-# set secrets
 if [ -n "$TRANSPORTURL" ]; then
-    crudini --set /var/lib/config-data/merged/neutron.conf DEFAULT transport_url $TRANSPORTURL
+    crudini --set /var/lib/config-data/merged/octavia.conf DEFAULT transport_url $TRANSPORTURL
 fi
 crudini --set ${SVC_CFG_MERGED} database connection mysql+pymysql://${DBUSER}:${DBPASSWORD}@${DBHOST}/${DB}
 crudini --set ${SVC_CFG_MERGED} keystone_authtoken password $PASSWORD

--- a/templates/octaviaamphoracontroller/bin/init.sh
+++ b/templates/octaviaamphoracontroller/bin/init.sh
@@ -24,6 +24,7 @@ export DBHOST=${DatabaseHost:?"Please specify a DatabaseHost variable."}
 export DBUSER=${DatabaseUser:?"Please specify a DatabaseUser variable."}
 export DBPASSWORD=${DatabasePassword:?"Please specify a DatabasePassword variable."}
 export DB=${DatabaseName:-"octavia"}
+export TRANSPORTURL=${TransportURL:-""}
 
 SVC_CFG=/etc/octavia/octavia.conf
 SVC_CFG_MERGED=/var/lib/config-data/merged/octavia.conf
@@ -40,6 +41,10 @@ for dir in /var/lib/config-data/default; do
     merge_config_dir ${dir}
 done
 
+# set secrets
+if [ -n "$TRANSPORTURL" ]; then
+    crudini --set /var/lib/config-data/merged/octavia.conf DEFAULT transport_url $TRANSPORTURL
+fi
 # set secrets
 crudini --set ${SVC_CFG_MERGED} database connection mysql+pymysql://${DBUSER}:${DBPASSWORD}@${DBHOST}/${DB}
 crudini --set ${SVC_CFG_MERGED} keystone_authtoken password $PASSWORD

--- a/templates/octaviaapi/bin/init.sh
+++ b/templates/octaviaapi/bin/init.sh
@@ -24,6 +24,7 @@ export DBHOST=${DatabaseHost:?"Please specify a DatabaseHost variable."}
 export DBUSER=${DatabaseUser:?"Please specify a DatabaseUser variable."}
 export DBPASSWORD=${DatabasePassword:?"Please specify a DatabasePassword variable."}
 export DB=${DatabaseName:-"octavia"}
+export TRANSPORTURL=${TransportURL:-""}
 
 SVC_CFG=/etc/octavia/octavia.conf
 SVC_CFG_MERGED=/var/lib/config-data/merged/octavia.conf
@@ -40,6 +41,10 @@ for dir in /var/lib/config-data/default; do
     merge_config_dir ${dir}
 done
 
+# set secrets
+if [ -n "$TRANSPORTURL" ]; then
+    crudini --set /var/lib/config-data/merged/octavia.conf DEFAULT transport_url $TRANSPORTURL
+fi
 # set secrets
 crudini --set ${SVC_CFG_MERGED} database connection mysql+pymysql://${DBUSER}:${DBPASSWORD}@${DBHOST}/${DB}
 crudini --set ${SVC_CFG_MERGED} keystone_authtoken password $PASSWORD

--- a/tests/kuttl/common/assert_sample_deployment.yaml
+++ b/tests/kuttl/common/assert_sample_deployment.yaml
@@ -177,6 +177,11 @@ spec:
             secretKeyRef:
               key: OctaviaPassword
               name: osp-secret
+        - name: TransportURL
+          valueFrom:
+            secretKeyRef:
+              key: transport_url
+              name: rabbitmq-transport-url-octavia-octavia-transport
         - name: DatabaseHost
           value: openstack
         - name: DatabaseName


### PR DESCRIPTION
Recent amphora controller support changes were missing the init.sh and initcontainer changes required for configuring the rabbitmq transport_url.