### PR TITLE
Create Nova flavors for Octavia

### DIFF
--- a/pkg/amphoracontrollers/flavors.go
+++ b/pkg/amphoracontrollers/flavors.go
@@ -1,0 +1,126 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package amphoracontrollers
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/go-logr/logr"
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/openstack/compute/v2/flavors"
+	keystonev1 "github.com/openstack-k8s-operators/keystone-operator/api/v1beta1"
+	"github.com/openstack-k8s-operators/lib-common/modules/common/helper"
+	"github.com/openstack-k8s-operators/lib-common/modules/openstack"
+	octaviav1 "github.com/openstack-k8s-operators/octavia-operator/api/v1beta1"
+	"github.com/openstack-k8s-operators/octavia-operator/pkg/octavia"
+)
+
+func ensureNovaFlavors(osclient *openstack.OpenStack, log *logr.Logger) (string, error) {
+	client, err := octavia.GetComputeClient(osclient)
+	if err != nil {
+		return "", err
+	}
+
+	// Get Octavia flavors
+	listOpts := flavors.ListOpts{
+		AccessType: flavors.AllAccess,
+	}
+	allPages, err := flavors.ListDetail(client, listOpts).AllPages()
+	if err != nil {
+		return "", err
+	}
+	allFlavors, err := flavors.ExtractFlavors(allPages)
+	if err != nil {
+		return "", err
+	}
+	amphoraFlavors := make(map[string]flavors.Flavor)
+	for _, flavor := range allFlavors {
+		if strings.HasPrefix(flavor.Name, "octavia-") {
+			amphoraFlavors[flavor.Name] = flavor
+		}
+	}
+
+	isPublic := false
+	// TODO(gthiemonge) we may consider updating the size of the disk
+	// 3GB is fine when enabling log offloading+disabling local disk storage
+	// but when using the defaults, the disk can be filled when testing network performances.
+	defaultFlavorsCreateOpts := []flavors.CreateOpts{
+		{
+			Name:        "octavia-amphora",
+			Description: "Flavor for Octavia amphora instances (1 vCPU, 1 GB RAM, 3 GB disk, default flavor)",
+			VCPUs:       1,
+			RAM:         1024,
+			Disk:        gophercloud.IntToPointer(3),
+			RxTxFactor:  1.0,
+			IsPublic:    &isPublic,
+		}, {
+			Name:        "octavia-amphora-4vcpus",
+			Description: "Flavor for Octavia amphora instances (4 vCPUs, 4 GB RAM, 3 GB disk)",
+			VCPUs:       4,
+			RAM:         4096,
+			Disk:        gophercloud.IntToPointer(3),
+			RxTxFactor:  1.0,
+			IsPublic:    &isPublic,
+		},
+	}
+	defaultFlavorID := ""
+	defaultFlavorName := defaultFlavorsCreateOpts[0].Name
+
+	// Default flavor already exists, get its ID
+	if flavor, ok := amphoraFlavors[defaultFlavorName]; ok {
+		defaultFlavorID = flavor.ID
+	}
+
+	// Create missing flavors
+	for idx, defaultFlavorOpts := range defaultFlavorsCreateOpts {
+		if _, ok := amphoraFlavors[defaultFlavorOpts.Name]; !ok {
+			log.Info(fmt.Sprintf("Creating Amphora flavor \"%s\"", defaultFlavorOpts.Name))
+			flavor, err := flavors.Create(client, defaultFlavorOpts).Extract()
+			if err != nil {
+				return "", err
+			}
+			if idx == 0 {
+				defaultFlavorID = flavor.ID
+			}
+		}
+	}
+
+	return defaultFlavorID, nil
+}
+
+// EnsureFlavors - enable that the Nova flavors for the amphora VMs are created
+//
+// returns the UUID of the default Nova flavor
+func EnsureFlavors(ctx context.Context, instance *octaviav1.OctaviaAmphoraController, log *logr.Logger, helper *helper.Helper) (string, error) {
+	keystoneAPI, err := keystonev1.GetKeystoneAPI(ctx, helper, instance.Namespace, map[string]string{})
+	if err != nil {
+		return "", err
+	}
+	osclient, _, err := octavia.GetAdminServiceClient(ctx, helper, keystoneAPI, octavia.ClientOpts{})
+	if err != nil {
+		return "", err
+	}
+
+	defaultNovaFlavorID, err := ensureNovaFlavors(osclient, log)
+	if err != nil {
+		return "", err
+	}
+
+	// TODO(gthiemonge) Create Octavia flavorprofiles and flavors when gophercloud support them
+
+	return defaultNovaFlavorID, nil
+}

--- a/pkg/amphoracontrollers/lb_mgmt_network.go
+++ b/pkg/amphoracontrollers/lb_mgmt_network.go
@@ -197,7 +197,7 @@ func EnsureLbMgmtNetworks(ctx context.Context, instance *octaviav1.OctaviaAmphor
 	if err != nil {
 		return "", err
 	}
-	o, _, err := octavia.GetAdminServiceClient(ctx, helper, keystoneAPI)
+	o, _, err := octavia.GetAdminServiceClient(ctx, helper, keystoneAPI, octavia.ClientOpts{SystemScope: true})
 	if err != nil {
 		return "", err
 	}

--- a/templates/octaviaamphoracontroller/config/octavia.conf
+++ b/templates/octaviaamphoracontroller/config/octavia.conf
@@ -28,6 +28,7 @@ port_detach_timeout=300
 [haproxy_amphora]
 [controller_worker]
 amp_boot_network_list={{ .LbMgmtNetworkId }}
+amp_flavor_id={{ .AmpFlavorId }}
 [task_flow]
 [oslo_messaging]
 # topic=octavia-rpc


### PR DESCRIPTION
Add support for system-scope Compute client.

Ensure that 2 nova flavors are created:
- octavia-amphora: 1 vCPU, 1GB RAM, 3GB disk
- octavia-amphora-4vcpus: 4 vCPU, 4GB RAM, 3GB disk

Flavors in previous releases used non-UUIDs as ID (octavia_65, etc...) and didn't have a clear naming convention (amphora*, octavia*). Don't force the ID of the new flavors, let Nova generates them.

octavia-amphora is the default flavor in Octavia