### PR TITLE
Various fixes for install_yamls_setup

### DIFF
--- a/install_yamls_setup/roles/podified_cp/files/clouds.yaml
+++ b/install_yamls_setup/roles/podified_cp/files/clouds.yaml
@@ -7,5 +7,6 @@ clouds:
       username: admin
       user_domain_name: Default
       project_domain_name: Default
+      verify: false
     identity_api_version: '3'
     region_name: regionOne

--- a/install_yamls_setup/roles/podified_cp/files/launch.json
+++ b/install_yamls_setup/roles/podified_cp/files/launch.json
@@ -7,12 +7,16 @@
             "request": "launch",
             "mode": "auto",
             "program": "${fileWorkspaceFolder}/main.go",
+            "args": ["-metrics-bind-address", ":${env:METRICS_PORT}",
+                     "-health-probe-bind-address", ":${env:HEALTH_PORT}"],
             "cwd": "${fileWorkspaceFolder}",
             "preLaunchTask": "Run make",
             "env": {
                 "WATCH_NAMESPACE": "openstack",
                 "OPERATOR_TEMPLATES": "./templates",
-                "ENABLE_WEBHOOKS": "false"
+                "ENABLE_WEBHOOKS": "false",
+                "METRICS_PORT": "8082",
+                "HEALTH_PORT": "8083"
             }
         }
     ]

--- a/install_yamls_setup/roles/podified_cp/files/octavia_v1beta1_octavia.yaml
+++ b/install_yamls_setup/roles/podified_cp/files/octavia_v1beta1_octavia.yaml
@@ -21,7 +21,7 @@ spec:
     serviceUser: octavia
     serviceAccount: octavia
     role: housekeeping
-    certssecret: todo
+    certssecret: octavia-amp-cert-data
     secret: osp-secret
     preserveJobs: false
     containerImage: quay.io/podified-antelope-centos9/openstack-octavia-housekeeping:current-podified
@@ -34,7 +34,7 @@ spec:
     serviceUser: octavia
     serviceAccount: octavia
     role: healthmanager
-    certssecret: todo
+    certssecret: octavia-amp-cert-data
     secret: osp-secret
     preserveJobs: false
     containerImage: quay.io/podified-antelope-centos9/openstack-octavia-health-manager:current-podified
@@ -47,7 +47,7 @@ spec:
     serviceUser: octavia
     serviceAccount: octavia
     role: worker
-    certssecret: todo
+    certssecret: octavia-amp-cert-data
     secret: osp-secret
     preserveJobs: false
     containerImage: quay.io/podified-antelope-centos9/openstack-octavia-worker:current-podified

--- a/install_yamls_setup/roles/podified_cp/tasks/main.yaml
+++ b/install_yamls_setup/roles/podified_cp/tasks/main.yaml
@@ -23,6 +23,7 @@
       - podman
       - python3
       - python3-pip
+      - https://github.com/txn2/kubefwd/releases/download/1.22.5/kubefwd_amd64.rpm
     state: latest
   become: yes
   tags: install
@@ -187,6 +188,7 @@
     - export OS_PASSWORD=12345678
     - export EDPM_COMPUTE_CEPH_ENABLED=false
     - export BMO_SETUP=false
+    - export KUBECONFIG=~/.kube/config
     - export PATH=$PATH:~/.crc/bin/oc
   tags: config
 
@@ -198,6 +200,10 @@
   tags: config
 
 # Now run the operator as a Go program locally (outside the Kubernetes cluster):
+#
+# First run kubefwd in the background so communication between local operator
+# and cluster is possible:
+# sudo -E kubefwd services -n openstack &
 #
 # Either using VSCode or directly in a shell:
 # In VSCode open the home folder and add the ~/octavia_operator folder to the

--- a/install_yamls_setup/roles/podified_cp/tasks/main.yaml
+++ b/install_yamls_setup/roles/podified_cp/tasks/main.yaml
@@ -111,10 +111,28 @@
       set +ex
       eval $(crc oc-env)
       oc login -u kubeadmin -p 12345678 https://api.crc.testing:6443
+      make attach_default_interface_cleanup
       make crc_attach_default_interface
       exit 0
     chdir: "~/install_yamls/devsetup"
   tags: crc
+
+# Without this there could be image pull limit errors when deploying rabbitmq
+# Based on https://docs.openshift.com/container-platform/4.13/openshift_images/managing_images/using-image-pull-secrets.html#images-update-global-pull-secret_using-image-pull-secrets
+- name: Add docker.io credentials to pull-secret in OSP cluster
+  shell:
+    cmd: |
+      set +ex
+      eval $(crc oc-env)
+      oc get secret/pull-secret -n openshift-config \
+        --template='{{ '{{' }} index .data ".dockerconfigjson" | base64decode{{ '}}' }}' \
+        >pull-secret.json
+      oc registry login --registry="docker.io" \
+        --auth-basic="{{ podman_dockerio_user }}:{{ podman_dockerio_password }}" \
+        --to=pull-secret.json
+      oc set data secret/pull-secret -n openshift-config \
+        --from-file=.dockerconfigjson=pull-secret.json
+  tags: pull-secret
 
 - name: Deploy openstack operators
   shell:
@@ -122,13 +140,18 @@
       set +ex
       eval $(crc oc-env)
       oc login -u kubeadmin -p 12345678 https://api.crc.testing:6443
-      oc project openstack-operators
-      for i in mariadb keystone ovn neutron rabbitmq ; do
-        make $i || break ; sleep 60 ; make ${i}_deploy || break
-      done
-      make infra
-      make memcached_deploy
+      NETWORK_ISOLATION=false make openstack 2>&1 | tee make_openstack.log
+      sleep 100
+      NETWORK_ISOLATION=false make openstack_deploy 2>&1 | tee make_openstack_deploy.log
       sleep 300
+      oc get csv -n openstack-operators octavia-operator.v0.0.1 -o json | \
+        jq -r 'del(.metadata.generation, .metadata.resourceVersion, .metadata.uid)'  > operator_csv.json
+      oc patch csv -n openstack-operators octavia-operator.v0.0.1 --type json \
+        -p="[{"op": "replace", "path": "/spec/install/spec/deployments/0/spec/replicas", \
+        "value": "0"}]"
+      sleep 10
+      oc patch csv -n openstack-operators octavia-operator.v0.0.1 --type=json \
+        -p="[{'op': 'remove', 'path': '/spec/webhookdefinitions'}]"
       oc completion bash | sudo tee /etc/bash_completion.d/oc_completion
       openstack complete | sudo tee /etc/bash_completion.d/osc.bash_completion
       exit 0
@@ -136,7 +159,7 @@
     chdir: "~/install_yamls"
   tags: crc
 
-- name: Export OS_CLOUD and OS_PASSWORD in .bashrc
+- name: Add exports to .bashrc
   lineinfile:
     path: ~/.bashrc
     line: "{{ item }}"
@@ -144,6 +167,9 @@
     - export PATH=$PATH:~/.crc/bin/oc
     - export OS_CLOUD=default
     - export OS_PASSWORD=12345678
+    - export EDPM_COMPUTE_CEPH_ENABLED=false
+    - export BMO_SETUP=false
+    - export KUBECONFIG=~/.kube/config
   tags: config
 
 - name: Copy ~/.tmux.conf
@@ -177,19 +203,6 @@
     path: /etc/sysctl.conf
     line: fs.inotify.max_user_watches=524288
   notify: "Apply sysctl"
-  tags: config
-
-- name: Add exports to .bashrc
-  lineinfile:
-    path: ~/.bashrc
-    line: "{{ item }}"
-  with_items:
-    - export OS_CLOUD=default
-    - export OS_PASSWORD=12345678
-    - export EDPM_COMPUTE_CEPH_ENABLED=false
-    - export BMO_SETUP=false
-    - export KUBECONFIG=~/.kube/config
-    - export PATH=$PATH:~/.crc/bin/oc
   tags: config
 
 - name: Copy PodSet CR with containerImage fields set


### PR DESCRIPTION
Issues solved include:
    - Image pull rate limiting resulted in download issues with docker.io
    - clouds.yaml was missing `verify: False`
    - Instead of deploying operators individually, which proved to be
      problematic, it now uses openstack operator and patches the CSV so
      octavia operator can run locally
    - kubefwd was needed in order to make connection between local operator and services in the cluster
