### PR TITLE
Change the label of the octavia controllers

### DIFF
--- a/api/bases/octavia.openstack.org_octaviaamphoracontrollers.yaml
+++ b/api/bases/octavia.openstack.org_octaviaamphoracontrollers.yaml
@@ -17,7 +17,7 @@ spec:
   versions:
   - additionalPrinterColumns:
     - description: NetworkAttachments
-      jsonPath: .status.spec.networkAttachments
+      jsonPath: .status.networkAttachments
       name: NetworkAttachments
       type: string
     - description: Status

--- a/api/v1beta1/amphoracontroller_types.go
+++ b/api/v1beta1/amphoracontroller_types.go
@@ -147,7 +147,7 @@ type OctaviaAmphoraControllerStatus struct {
 
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
-//+kubebuilder:printcolumn:name="NetworkAttachments",type="string",JSONPath=".status.spec.networkAttachments",description="NetworkAttachments"
+//+kubebuilder:printcolumn:name="NetworkAttachments",type="string",JSONPath=".status.networkAttachments",description="NetworkAttachments"
 //+kubebuilder:printcolumn:name="Status",type="string",JSONPath=".status.conditions[0].status",description="Status"
 //+kubebuilder:printcolumn:name="Message",type="string",JSONPath=".status.conditions[0].message",description="Message"
 

--- a/config/crd/bases/octavia.openstack.org_octaviaamphoracontrollers.yaml
+++ b/config/crd/bases/octavia.openstack.org_octaviaamphoracontrollers.yaml
@@ -17,7 +17,7 @@ spec:
   versions:
   - additionalPrinterColumns:
     - description: NetworkAttachments
-      jsonPath: .status.spec.networkAttachments
+      jsonPath: .status.networkAttachments
       name: NetworkAttachments
       type: string
     - description: Status

--- a/controllers/amphoracontroller_controller.go
+++ b/controllers/amphoracontroller_controller.go
@@ -38,7 +38,6 @@ import (
 	neutronv1 "github.com/openstack-k8s-operators/neutron-operator/api/v1beta1"
 	octaviav1 "github.com/openstack-k8s-operators/octavia-operator/api/v1beta1"
 	"github.com/openstack-k8s-operators/octavia-operator/pkg/amphoracontrollers"
-	"github.com/openstack-k8s-operators/octavia-operator/pkg/octavia"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	k8s_errors "k8s.io/apimachinery/pkg/api/errors"
@@ -316,7 +315,7 @@ func (r *OctaviaAmphoraControllerReconciler) reconcileNormal(ctx context.Context
 	//
 
 	serviceLabels := map[string]string{
-		common.AppSelector: octavia.ServiceName,
+		common.AppSelector: instance.ObjectMeta.Name,
 	}
 
 	// Define a new Deployment object
@@ -399,7 +398,7 @@ func (r *OctaviaAmphoraControllerReconciler) generateServiceConfigMaps(
 	templateVars OctaviaTemplateVars,
 ) error {
 	r.Log.Info(fmt.Sprintf("generating service config map for %s (%s)", instance.Name, instance.Kind))
-	cmLabels := labels.GetLabels(instance, labels.GetGroupLabel(octavia.ServiceName), map[string]string{})
+	cmLabels := labels.GetLabels(instance, labels.GetGroupLabel(instance.ObjectMeta.Name), map[string]string{})
 	customData := map[string]string{common.CustomServiceConfigFileName: instance.Spec.CustomServiceConfig}
 	for key, data := range instance.Spec.DefaultConfigOverwrite {
 		customData[key] = data


### PR DESCRIPTION
octavia-worker, healthmonitor and housekeeping services shared the same label "octavia". But that was confusing as some resources like NetworkAttachments are linked to the label and not the pod name. Each service has now a unique label. That fixes a bug with the list of NetworkAttachments as they all appeared only in the status of one pod.

The commit also fixed the json path for printing the NetworkAttachments

Note: for an unknown reason (to me), this PR may require to delete the previous deployment of these services:
oc delete deployment octavia-worker
oc delete deployment octavia-housekeeping
oc delete deployment octavia-healthmanager
