### PR TITLE
Amphora controller pods need privileges

### DIFF
--- a/controllers/amphoracontroller_controller.go
+++ b/controllers/amphoracontroller_controller.go
@@ -72,6 +72,12 @@ func (r *OctaviaAmphoraControllerReconciler) GetLogger(ctx context.Context) logr
 //+kubebuilder:rbac:groups=octavia.openstack.org,resources=octaviaamphoracontrollers/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=octavia.openstack.org,resources=octaviaamphoracontrollers/finalizers,verbs=update
 // +kubebuilder:rbac:groups=k8s.cni.cncf.io,resources=network-attachment-definitions,verbs=get;list;watch
+// +kubebuilder:rbac:groups="security.openshift.io",resourceNames=anyuid;privileged,resources=securitycontextconstraints,verbs=use
+// +kubebuilder:rbac:groups="",resources=serviceaccounts,verbs=get;list;watch;create;update
+// +kubebuilder:rbac:groups="rbac.authorization.k8s.io",resources=roles,verbs=get;list;watch;create;update
+// +kubebuilder:rbac:groups="rbac.authorization.k8s.io",resources=rolebindings,verbs=get;list;watch;create;update
+// service account permissions that are needed to grant permission to the above
+// +kubebuilder:rbac:groups="",resources=pods,verbs=create;delete;get;list;patch;update;watch
 
 // Reconcile implementation of the reconcile loop for amphora
 // controllers like the octavia housekeeper, worker and health manager

--- a/pkg/amphoracontrollers/daemonset.go
+++ b/pkg/amphoracontrollers/daemonset.go
@@ -36,6 +36,8 @@ func DaemonSet(
 	labels map[string]string,
 	annotations map[string]string,
 ) *appsv1.DaemonSet {
+	runAsUser := int64(0)
+	privileged := true
 	serviceName := fmt.Sprintf("octavia-%s", instance.Spec.Role)
 
 	// The API pod has an extra volume so the API and the provider agent can
@@ -107,6 +109,14 @@ func DaemonSet(
 							Resources:      instance.Spec.Resources,
 							ReadinessProbe: readinessProbe,
 							LivenessProbe:  livenessProbe,
+							SecurityContext: &corev1.SecurityContext{
+								Capabilities: &corev1.Capabilities{
+									Add:  []corev1.Capability{"NET_ADMIN", "SYS_ADMIN", "SYS_NICE"},
+									Drop: []corev1.Capability{},
+								},
+								RunAsUser:  &runAsUser,
+								Privileged: &privileged,
+							},
 						},
 					},
 					Volumes: volumes,


### PR DESCRIPTION
In order to configure connectivity to the ovn controller pods, the amphora controller pods need to run ip commands such as ip addr add and ip route. This patch makes an initial step in configuring these privileges. It may be possible to be more selective after experimentation.