### PR TITLE
Amp controller restructuring

### DIFF
--- a/api/bases/octavia.openstack.org_octaviaamphoracontrollers.yaml
+++ b/api/bases/octavia.openstack.org_octaviaamphoracontrollers.yaml
@@ -74,15 +74,6 @@ spec:
                   - name
                   type: object
                 type: array
-              certsPassphraseSecret:
-                default: octavia-ca-passphrase
-                description: Name of secret containing passphrase for the CA private
-                  keys
-                type: string
-              certsSecret:
-                description: LoadBalancerCerts - Secret containing certs for securing
-                  communication with amphora based Load Balancers
-                type: string
               containerImage:
                 description: ContainerImage - Amphora Controller Container Image URL
                 type: string
@@ -227,16 +218,6 @@ spec:
                 default: octavia
                 description: 'ServiceUser - service user name (TODO: beagles, do we
                   need this at all)'
-                type: string
-              sshPrivkeySecret:
-                description: LoadBalancerSSHPrivKey - The name of the secret that
-                  will be used to store the private key for connecting to amphorae
-                  via SSH. Only used when no public key was defined and a new key
-                  pair needs to be generated.
-                type: string
-              sshPubkey:
-                description: LoadBalancerSSHPubKey - The name of the ConfigMap containing
-                  the pubilc key for connecting to the amphorae via SSH
                 type: string
               tenantName:
                 default: service

--- a/api/bases/octavia.openstack.org_octavias.yaml
+++ b/api/bases/octavia.openstack.org_octavias.yaml
@@ -68,11 +68,6 @@ spec:
                   - name
                   type: object
                 type: array
-              certsSecret:
-                default: octavia-certs-secret
-                description: LoadBalancerCerts - Secret containing certs for securing
-                  communication with amphora based Load Balancers
-                type: string
               customServiceConfig:
                 default: '# add your customization here'
                 description: CustomServiceConfig - customize the service config using
@@ -483,15 +478,6 @@ spec:
                       - name
                       type: object
                     type: array
-                  certsPassphraseSecret:
-                    default: octavia-ca-passphrase
-                    description: Name of secret containing passphrase for the CA private
-                      keys
-                    type: string
-                  certsSecret:
-                    description: LoadBalancerCerts - Secret containing certs for securing
-                      communication with amphora based Load Balancers
-                    type: string
                   containerImage:
                     description: ContainerImage - Amphora Controller Container Image
                       URL
@@ -638,17 +624,6 @@ spec:
                     default: octavia
                     description: 'ServiceUser - service user name (TODO: beagles,
                       do we need this at all)'
-                    type: string
-                  sshPrivkeySecret:
-                    description: LoadBalancerSSHPrivKey - The name of the secret that
-                      will be used to store the private key for connecting to amphorae
-                      via SSH. Only used when no public key was defined and a new
-                      key pair needs to be generated.
-                    type: string
-                  sshPubkey:
-                    description: LoadBalancerSSHPubKey - The name of the ConfigMap
-                      containing the pubilc key for connecting to the amphorae via
-                      SSH
                     type: string
                   tenantName:
                     default: service
@@ -693,15 +668,6 @@ spec:
                       - name
                       type: object
                     type: array
-                  certsPassphraseSecret:
-                    default: octavia-ca-passphrase
-                    description: Name of secret containing passphrase for the CA private
-                      keys
-                    type: string
-                  certsSecret:
-                    description: LoadBalancerCerts - Secret containing certs for securing
-                      communication with amphora based Load Balancers
-                    type: string
                   containerImage:
                     description: ContainerImage - Amphora Controller Container Image
                       URL
@@ -848,17 +814,6 @@ spec:
                     default: octavia
                     description: 'ServiceUser - service user name (TODO: beagles,
                       do we need this at all)'
-                    type: string
-                  sshPrivkeySecret:
-                    description: LoadBalancerSSHPrivKey - The name of the secret that
-                      will be used to store the private key for connecting to amphorae
-                      via SSH. Only used when no public key was defined and a new
-                      key pair needs to be generated.
-                    type: string
-                  sshPubkey:
-                    description: LoadBalancerSSHPubKey - The name of the ConfigMap
-                      containing the pubilc key for connecting to the amphorae via
-                      SSH
                     type: string
                   tenantName:
                     default: service
@@ -903,15 +858,6 @@ spec:
                       - name
                       type: object
                     type: array
-                  certsPassphraseSecret:
-                    default: octavia-ca-passphrase
-                    description: Name of secret containing passphrase for the CA private
-                      keys
-                    type: string
-                  certsSecret:
-                    description: LoadBalancerCerts - Secret containing certs for securing
-                      communication with amphora based Load Balancers
-                    type: string
                   containerImage:
                     description: ContainerImage - Amphora Controller Container Image
                       URL
@@ -1058,17 +1004,6 @@ spec:
                     default: octavia
                     description: 'ServiceUser - service user name (TODO: beagles,
                       do we need this at all)'
-                    type: string
-                  sshPrivkeySecret:
-                    description: LoadBalancerSSHPrivKey - The name of the secret that
-                      will be used to store the private key for connecting to amphorae
-                      via SSH. Only used when no public key was defined and a new
-                      key pair needs to be generated.
-                    type: string
-                  sshPubkey:
-                    description: LoadBalancerSSHPubKey - The name of the ConfigMap
-                      containing the pubilc key for connecting to the amphorae via
-                      SSH
                     type: string
                   tenantName:
                     default: service
@@ -1133,7 +1068,6 @@ spec:
                   the pubilc key for connecting to the amphorae via SSH
                 type: string
             required:
-            - certsSecret
             - databaseInstance
             - octaviaAPI
             - rabbitMqClusterName

--- a/api/v1beta1/amphoracontroller_types.go
+++ b/api/v1beta1/amphoracontroller_types.go
@@ -71,26 +71,6 @@ type OctaviaAmphoraControllerSpec struct {
 	Secret string `json:"secret"`
 
 	// +kubebuilder:validation:Optional
-	// LoadBalancerCerts - Secret containing certs for securing communication with amphora based Load Balancers
-	LoadBalancerCerts string `json:"certsSecret"`
-
-	// +kubebuilder:validation:Optional
-	// +kubebuilder:default=octavia-ca-passphrase
-	// Name of secret containing passphrase for the CA private keys
-	CAKeyPassphraseSecret string `json:"certsPassphraseSecret"`
-
-	// +kubebuilder:validation:Optional
-	// LoadBalancerSSHPubKey - The name of the ConfigMap containing the
-	// pubilc key for connecting to the amphorae via SSH
-	LoadBalancerSSHPubKey string `json:"sshPubkey,omitempty"`
-
-	// +kubebuilder:validation:Optional
-	// LoadBalancerSSHPrivKey - The name of the secret that will be used to
-	// store the private key for connecting to amphorae via SSH. Only used
-	// when no public key was defined and a new key pair needs to be generated.
-	LoadBalancerSSHPrivKey string `json:"sshPrivkeySecret,omitempty"`
-
-	// +kubebuilder:validation:Optional
 	// +kubebuilder:default={database: OctaviaDatabasePassword, service: OctaviaPassword}
 	// PasswordSelectors - Selectors to identify the DB and AdminUser password from the Secret
 	PasswordSelectors PasswordSelector `json:"passwordSelectors,omitempty"`

--- a/api/v1beta1/octavia_types.go
+++ b/api/v1beta1/octavia_types.go
@@ -117,11 +117,6 @@ type OctaviaSpec struct {
 	// +kubebuilder:default={manageLbMgmtNetworks: true, subnetIpVersion: 4}
 	LbMgmtNetworks OctaviaLbMgmtNetworks `json:"lbMgmtNetwork"`
 
-	// +kubebuilder:validation:Required
-	// +kubebuilder:default=octavia-certs-secret
-	// LoadBalancerCerts - Secret containing certs for securing communication with amphora based Load Balancers
-	LoadBalancerCerts string `json:"certsSecret"`
-
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:default=octavia-ssh-pubkey
 	// LoadBalancerSSHPubKey - The name of the ConfigMap containing the

--- a/config/crd/bases/octavia.openstack.org_octaviaamphoracontrollers.yaml
+++ b/config/crd/bases/octavia.openstack.org_octaviaamphoracontrollers.yaml
@@ -74,15 +74,6 @@ spec:
                   - name
                   type: object
                 type: array
-              certsPassphraseSecret:
-                default: octavia-ca-passphrase
-                description: Name of secret containing passphrase for the CA private
-                  keys
-                type: string
-              certsSecret:
-                description: LoadBalancerCerts - Secret containing certs for securing
-                  communication with amphora based Load Balancers
-                type: string
               containerImage:
                 description: ContainerImage - Amphora Controller Container Image URL
                 type: string
@@ -227,16 +218,6 @@ spec:
                 default: octavia
                 description: 'ServiceUser - service user name (TODO: beagles, do we
                   need this at all)'
-                type: string
-              sshPrivkeySecret:
-                description: LoadBalancerSSHPrivKey - The name of the secret that
-                  will be used to store the private key for connecting to amphorae
-                  via SSH. Only used when no public key was defined and a new key
-                  pair needs to be generated.
-                type: string
-              sshPubkey:
-                description: LoadBalancerSSHPubKey - The name of the ConfigMap containing
-                  the pubilc key for connecting to the amphorae via SSH
                 type: string
               tenantName:
                 default: service

--- a/config/crd/bases/octavia.openstack.org_octavias.yaml
+++ b/config/crd/bases/octavia.openstack.org_octavias.yaml
@@ -68,11 +68,6 @@ spec:
                   - name
                   type: object
                 type: array
-              certsSecret:
-                default: octavia-certs-secret
-                description: LoadBalancerCerts - Secret containing certs for securing
-                  communication with amphora based Load Balancers
-                type: string
               customServiceConfig:
                 default: '# add your customization here'
                 description: CustomServiceConfig - customize the service config using
@@ -483,15 +478,6 @@ spec:
                       - name
                       type: object
                     type: array
-                  certsPassphraseSecret:
-                    default: octavia-ca-passphrase
-                    description: Name of secret containing passphrase for the CA private
-                      keys
-                    type: string
-                  certsSecret:
-                    description: LoadBalancerCerts - Secret containing certs for securing
-                      communication with amphora based Load Balancers
-                    type: string
                   containerImage:
                     description: ContainerImage - Amphora Controller Container Image
                       URL
@@ -638,17 +624,6 @@ spec:
                     default: octavia
                     description: 'ServiceUser - service user name (TODO: beagles,
                       do we need this at all)'
-                    type: string
-                  sshPrivkeySecret:
-                    description: LoadBalancerSSHPrivKey - The name of the secret that
-                      will be used to store the private key for connecting to amphorae
-                      via SSH. Only used when no public key was defined and a new
-                      key pair needs to be generated.
-                    type: string
-                  sshPubkey:
-                    description: LoadBalancerSSHPubKey - The name of the ConfigMap
-                      containing the pubilc key for connecting to the amphorae via
-                      SSH
                     type: string
                   tenantName:
                     default: service
@@ -693,15 +668,6 @@ spec:
                       - name
                       type: object
                     type: array
-                  certsPassphraseSecret:
-                    default: octavia-ca-passphrase
-                    description: Name of secret containing passphrase for the CA private
-                      keys
-                    type: string
-                  certsSecret:
-                    description: LoadBalancerCerts - Secret containing certs for securing
-                      communication with amphora based Load Balancers
-                    type: string
                   containerImage:
                     description: ContainerImage - Amphora Controller Container Image
                       URL
@@ -848,17 +814,6 @@ spec:
                     default: octavia
                     description: 'ServiceUser - service user name (TODO: beagles,
                       do we need this at all)'
-                    type: string
-                  sshPrivkeySecret:
-                    description: LoadBalancerSSHPrivKey - The name of the secret that
-                      will be used to store the private key for connecting to amphorae
-                      via SSH. Only used when no public key was defined and a new
-                      key pair needs to be generated.
-                    type: string
-                  sshPubkey:
-                    description: LoadBalancerSSHPubKey - The name of the ConfigMap
-                      containing the pubilc key for connecting to the amphorae via
-                      SSH
                     type: string
                   tenantName:
                     default: service
@@ -903,15 +858,6 @@ spec:
                       - name
                       type: object
                     type: array
-                  certsPassphraseSecret:
-                    default: octavia-ca-passphrase
-                    description: Name of secret containing passphrase for the CA private
-                      keys
-                    type: string
-                  certsSecret:
-                    description: LoadBalancerCerts - Secret containing certs for securing
-                      communication with amphora based Load Balancers
-                    type: string
                   containerImage:
                     description: ContainerImage - Amphora Controller Container Image
                       URL
@@ -1058,17 +1004,6 @@ spec:
                     default: octavia
                     description: 'ServiceUser - service user name (TODO: beagles,
                       do we need this at all)'
-                    type: string
-                  sshPrivkeySecret:
-                    description: LoadBalancerSSHPrivKey - The name of the secret that
-                      will be used to store the private key for connecting to amphorae
-                      via SSH. Only used when no public key was defined and a new
-                      key pair needs to be generated.
-                    type: string
-                  sshPubkey:
-                    description: LoadBalancerSSHPubKey - The name of the ConfigMap
-                      containing the pubilc key for connecting to the amphorae via
-                      SSH
                     type: string
                   tenantName:
                     default: service
@@ -1133,7 +1068,6 @@ spec:
                   the pubilc key for connecting to the amphorae via SSH
                 type: string
             required:
-            - certsSecret
             - databaseInstance
             - octaviaAPI
             - rabbitMqClusterName

--- a/controllers/amphoracontroller_controller.go
+++ b/controllers/amphoracontroller_controller.go
@@ -449,6 +449,20 @@ func (r *OctaviaAmphoraControllerReconciler) generateServiceConfigMaps(
 	caPassSecret, _, err := secret.GetSecret(
 		ctx, helper, serverCAPassSecretName, instance.Namespace)
 	if err != nil {
+		if k8s_errors.IsNotFound(err) {
+			instance.Status.Conditions.Set(condition.FalseCondition(
+				condition.InputReadyCondition,
+				condition.RequestedReason,
+				condition.SeverityInfo,
+				condition.InputReadyWaitingMessage))
+			return fmt.Errorf("OpenStack secret %s not found", instance.Spec.Secret)
+		}
+		instance.Status.Conditions.Set(condition.FalseCondition(
+			condition.InputReadyCondition,
+			condition.ErrorReason,
+			condition.SeverityWarning,
+			condition.InputReadyErrorMessage,
+			err.Error()))
 		return err
 	}
 

--- a/controllers/amphoracontroller_controller.go
+++ b/controllers/amphoracontroller_controller.go
@@ -455,7 +455,8 @@ func (r *OctaviaAmphoraControllerReconciler) generateServiceConfigMaps(
 				condition.RequestedReason,
 				condition.SeverityInfo,
 				condition.InputReadyWaitingMessage))
-			return fmt.Errorf("OpenStack secret %s not found", instance.Spec.Secret)
+			return fmt.Errorf("OpenStack server CA passphrase secret %s not found",
+				serverCAPassSecretName)
 		}
 		instance.Status.Conditions.Set(condition.FalseCondition(
 			condition.InputReadyCondition,

--- a/pkg/amphoracontrollers/daemonset.go
+++ b/pkg/amphoracontrollers/daemonset.go
@@ -43,7 +43,9 @@ func DaemonSet(
 	// The API pod has an extra volume so the API and the provider agent can
 	// communicate with each other.
 	volumes := octavia.GetVolumes(instance.Name)
-	volumes = append(volumes, GetCertVolume(instance.Spec.LoadBalancerCerts)...)
+	parentOctaviaName := GetOwningOctaviaControllerName(instance)
+	certsSecretName := fmt.Sprintf("%s-certs-secret", parentOctaviaName)
+	volumes = append(volumes, GetCertVolume(certsSecretName)...)
 
 	volumeMounts := octavia.GetVolumeMounts(serviceName)
 	volumeMounts = append(volumeMounts, GetCertVolumeMount()...)

--- a/pkg/octavia/amphora_ssh.go
+++ b/pkg/octavia/amphora_ssh.go
@@ -12,7 +12,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package amphoracontrollers
+package octavia
 
 import (
 	"context"
@@ -31,7 +31,6 @@ import (
 	"github.com/openstack-k8s-operators/lib-common/modules/common/secret"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/util"
 	octaviav1 "github.com/openstack-k8s-operators/octavia-operator/api/v1beta1"
-	"github.com/openstack-k8s-operators/octavia-operator/pkg/octavia"
 	"golang.org/x/crypto/ssh"
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
@@ -71,7 +70,7 @@ func generateECDSAKeys() (pubKey string, privKey string, err error) {
 
 func storePrivateKeyAsSecret(
 	ctx context.Context,
-	instance *octaviav1.OctaviaAmphoraController,
+	instance *octaviav1.Octavia,
 	h *helper.Helper,
 	privKey string,
 ) error {
@@ -91,7 +90,7 @@ func storePrivateKeyAsSecret(
 
 func storePublicKeyAsConfigMap(
 	ctx context.Context,
-	instance *octaviav1.OctaviaAmphoraController,
+	instance *octaviav1.Octavia,
 	h *helper.Helper,
 	pubKey string,
 ) error {
@@ -111,7 +110,7 @@ func storePublicKeyAsConfigMap(
 
 func uploadKeypair(
 	ctx context.Context,
-	instance *octaviav1.OctaviaAmphoraController,
+	instance *octaviav1.Octavia,
 	h *helper.Helper,
 	pubKey string) error {
 	osClient, err := GetOpenstackClient(ctx, instance, h)
@@ -119,7 +118,7 @@ func uploadKeypair(
 		return fmt.Errorf("Error getting openstack client: %w", err)
 	}
 
-	computeClient, err := octavia.GetComputeClient(osClient)
+	computeClient, err := GetComputeClient(osClient)
 	if err != nil {
 		return fmt.Errorf("Error getting compute client: %w", err)
 	}
@@ -164,7 +163,7 @@ func uploadKeypair(
 // EnsureAmpSSHConfig ensures amphora SSH configuration is set up
 func EnsureAmpSSHConfig(
 	ctx context.Context,
-	instance *octaviav1.OctaviaAmphoraController,
+	instance *octaviav1.Octavia,
 	h *helper.Helper,
 	log *logr.Logger,
 ) error {

--- a/pkg/octavia/common.go
+++ b/pkg/octavia/common.go
@@ -12,7 +12,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package amphoracontrollers
+package octavia
 
 import (
 	"context"
@@ -21,36 +21,21 @@ import (
 	"github.com/openstack-k8s-operators/lib-common/modules/common/helper"
 	"github.com/openstack-k8s-operators/lib-common/modules/openstack"
 	octaviav1 "github.com/openstack-k8s-operators/octavia-operator/api/v1beta1"
-	"github.com/openstack-k8s-operators/octavia-operator/pkg/octavia"
-
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // GetOpenstackClient returns an openstack admin service client object
 func GetOpenstackClient(
 	ctx context.Context,
-	instance *octaviav1.OctaviaAmphoraController,
+	instance *octaviav1.Octavia,
 	h *helper.Helper,
 ) (*openstack.OpenStack, error) {
 	keystoneAPI, err := keystonev1.GetKeystoneAPI(ctx, h, instance.Namespace, map[string]string{})
 	if err != nil {
 		return nil, err
 	}
-	o, _, err := octavia.GetAdminServiceClient(ctx, h, keystoneAPI)
+	o, _, err := GetAdminServiceClient(ctx, h, keystoneAPI)
 	if err != nil {
 		return nil, err
 	}
 	return o, nil
-}
-
-// GetOwningOctaviaControllerName - Given a OctaviaHousekeeping, OctaviaHealthmanager or OctaviaWorker
-// object, returning the parent Octavia object that created it (if any)
-func GetOwningOctaviaControllerName(instance client.Object) string {
-	for _, ownerRef := range instance.GetOwnerReferences() {
-		if ownerRef.Kind == "Octavia" {
-			return ownerRef.Name
-		}
-	}
-
-	return ""
 }


### PR DESCRIPTION
Resolves errors about permissions when a amphora controller tries to modify a resource that was created/owned by another controller. Now those resources are owned by the parent Octavia controller and amphora controllers get read access only.

- Moved SSH key management to octavia controller
- Moved Certs management to octavia controller
- Names of certs secret and ca passphrase secret are now fix and depend on the name of the octavia instance (which is "octavia" normally)

Depends-On: install_yamls#742