### PR TITLE
Removing replica count for daemonsets

### DIFF
--- a/tests/kuttl/tests/octavia_scale/04-scale-down-zero-octaviaapi.yaml
+++ b/tests/kuttl/tests/octavia_scale/04-scale-down-zero-octaviaapi.yaml
@@ -3,6 +3,3 @@ kind: TestStep
 commands:
   - script: |
       oc patch octavia -n $NAMESPACE octavia --type='json' -p='[{"op": "replace", "path": "/spec/octaviaAPI/replicas", "value":0}]'
-      oc patch octavia -n $NAMESPACE octavia --type='json' -p='[{"op": "replace", "path": "/spec/octaviaHousekeeping/replicas", "value":0}]'
-      oc patch octavia -n $NAMESPACE octavia --type='json' -p='[{"op": "replace", "path": "/spec/octaviaWorker/replicas", "value":0}]'
-      oc patch octavia -n $NAMESPACE octavia --type='json' -p='[{"op": "replace", "path": "/spec/octaviaHealthManager/replicas", "value":0}]'


### PR DESCRIPTION
Amphora controllers were converted to daemonsets so don't have replica counts any more.