### PR TITLE
Set security group ID in ampcontroller conf

### DIFF
--- a/api/bases/octavia.openstack.org_octaviaamphoracontrollers.yaml
+++ b/api/bases/octavia.openstack.org_octaviaamphoracontrollers.yaml
@@ -109,6 +109,9 @@ spec:
               lbMgmtNetworkID:
                 default: ""
                 type: string
+              lbSecurityGroupID:
+                default: ""
+                type: string
               networkAttachments:
                 description: NetworkAttachments is a list of NetworkAttachment resource
                   names to expose the services to the given network

--- a/api/bases/octavia.openstack.org_octavias.yaml
+++ b/api/bases/octavia.openstack.org_octavias.yaml
@@ -522,6 +522,9 @@ spec:
                   lbMgmtNetworkID:
                     default: ""
                     type: string
+                  lbSecurityGroupID:
+                    default: ""
+                    type: string
                   networkAttachments:
                     description: NetworkAttachments is a list of NetworkAttachment
                       resource names to expose the services to the given network
@@ -708,6 +711,9 @@ spec:
                   lbMgmtNetworkID:
                     default: ""
                     type: string
+                  lbSecurityGroupID:
+                    default: ""
+                    type: string
                   networkAttachments:
                     description: NetworkAttachments is a list of NetworkAttachment
                       resource names to expose the services to the given network
@@ -892,6 +898,9 @@ spec:
                       service config dir in /etc/<service> . TODO: -> implement'
                     type: object
                   lbMgmtNetworkID:
+                    default: ""
+                    type: string
+                  lbSecurityGroupID:
                     default: ""
                     type: string
                   networkAttachments:

--- a/api/v1beta1/amphoracontroller_types.go
+++ b/api/v1beta1/amphoracontroller_types.go
@@ -127,6 +127,10 @@ type OctaviaAmphoraControllerSpecCore struct {
 	LbMgmtNetworkID string `json:"lbMgmtNetworkID"`
 
 	// +kubebuilder:validation:Optional
+	// +kubebuilder:default=""
+	LbSecurityGroupID string `json:"lbSecurityGroupID"`
+
+	// +kubebuilder:validation:Optional
 	// +kubebuilder:default={}
 	// AmphoraCustomFlavors - User-defined flavors for Octavia
 	AmphoraCustomFlavors []OctaviaAmphoraFlavor `json:"amphoraCustomFlavors,omitempty"`

--- a/config/crd/bases/octavia.openstack.org_octaviaamphoracontrollers.yaml
+++ b/config/crd/bases/octavia.openstack.org_octaviaamphoracontrollers.yaml
@@ -109,6 +109,9 @@ spec:
               lbMgmtNetworkID:
                 default: ""
                 type: string
+              lbSecurityGroupID:
+                default: ""
+                type: string
               networkAttachments:
                 description: NetworkAttachments is a list of NetworkAttachment resource
                   names to expose the services to the given network

--- a/config/crd/bases/octavia.openstack.org_octavias.yaml
+++ b/config/crd/bases/octavia.openstack.org_octavias.yaml
@@ -522,6 +522,9 @@ spec:
                   lbMgmtNetworkID:
                     default: ""
                     type: string
+                  lbSecurityGroupID:
+                    default: ""
+                    type: string
                   networkAttachments:
                     description: NetworkAttachments is a list of NetworkAttachment
                       resource names to expose the services to the given network
@@ -708,6 +711,9 @@ spec:
                   lbMgmtNetworkID:
                     default: ""
                     type: string
+                  lbSecurityGroupID:
+                    default: ""
+                    type: string
                   networkAttachments:
                     description: NetworkAttachments is a list of NetworkAttachment
                       resource names to expose the services to the given network
@@ -892,6 +898,9 @@ spec:
                       service config dir in /etc/<service> . TODO: -> implement'
                     type: object
                   lbMgmtNetworkID:
+                    default: ""
+                    type: string
+                  lbSecurityGroupID:
                     default: ""
                     type: string
                   networkAttachments:

--- a/controllers/amphoracontroller_controller.go
+++ b/controllers/amphoracontroller_controller.go
@@ -65,6 +65,7 @@ type OctaviaAmphoraControllerReconciler struct {
 type OctaviaTemplateVars struct {
 	LbMgmtNetworkID        string
 	AmphoraDefaultFlavorID string
+	LbSecurityGroupID      string
 }
 
 // GetLogger returns a logger object with a prefix of "controller.name" and additional controller context fields
@@ -264,6 +265,7 @@ func (r *OctaviaAmphoraControllerReconciler) reconcileNormal(ctx context.Context
 	templateVars := OctaviaTemplateVars{
 		LbMgmtNetworkID:        instance.Spec.LbMgmtNetworkID,
 		AmphoraDefaultFlavorID: defaultFlavorID,
+		LbSecurityGroupID:      instance.Spec.LbSecurityGroupID,
 	}
 
 	err = r.generateServiceConfigMaps(ctx, instance, helper, &configMapVars, templateVars, ospSecret)
@@ -557,6 +559,7 @@ func (r *OctaviaAmphoraControllerReconciler) generateServiceConfigMaps(
 	templateParameters["KeystonePublicURL"] = keystonePublicURL
 	templateParameters["ServiceRoleName"] = spec.Role
 	templateParameters["LbMgmtNetworkId"] = templateVars.LbMgmtNetworkID
+	templateParameters["LbSecurityGroupId"] = templateVars.LbSecurityGroupID
 	templateParameters["AmpFlavorId"] = templateVars.AmphoraDefaultFlavorID
 	templateParameters["NovaSshKeyPair"] = octavia.NovaKeyPairName
 	serverCAPassphrase := caPassSecret.Data["server-ca-passphrase"]

--- a/controllers/octavia_controller.go
+++ b/controllers/octavia_controller.go
@@ -614,7 +614,7 @@ func (r *OctaviaReconciler) reconcileNormal(ctx context.Context, instance *octav
 	}
 	Log.Info(fmt.Sprintf("Using management network \"%s\"", networkInfo.TenantNetworkID))
 
-	octaviaHealthManager, op, err := r.amphoraControllerDaemonSetCreateOrUpdate(instance, networkInfo.TenantNetworkID,
+	octaviaHealthManager, op, err := r.amphoraControllerDaemonSetCreateOrUpdate(instance, networkInfo,
 		instance.Spec.OctaviaHealthManager, octaviav1.HealthManager)
 	if err != nil {
 		instance.Status.Conditions.Set(condition.FalseCondition(
@@ -647,7 +647,7 @@ func (r *OctaviaReconciler) reconcileNormal(ctx context.Context, instance *octav
 	}
 
 	// Skip the other amphora controller pods until the health managers are all up and running.
-	octaviaHousekeeping, op, err := r.amphoraControllerDaemonSetCreateOrUpdate(instance, networkInfo.TenantNetworkID,
+	octaviaHousekeeping, op, err := r.amphoraControllerDaemonSetCreateOrUpdate(instance, networkInfo,
 		instance.Spec.OctaviaHousekeeping, octaviav1.Housekeeping)
 	if err != nil {
 		instance.Status.Conditions.Set(condition.FalseCondition(
@@ -671,7 +671,7 @@ func (r *OctaviaReconciler) reconcileNormal(ctx context.Context, instance *octav
 		instance.Status.Conditions.MarkTrue(amphoraControllerReadyCondition(octaviav1.Housekeeping), condition.DeploymentReadyMessage)
 	}
 
-	octaviaWorker, op, err := r.amphoraControllerDaemonSetCreateOrUpdate(instance, networkInfo.TenantNetworkID,
+	octaviaWorker, op, err := r.amphoraControllerDaemonSetCreateOrUpdate(instance, networkInfo,
 		instance.Spec.OctaviaWorker, octaviav1.Worker)
 	if err != nil {
 		instance.Status.Conditions.Set(condition.FalseCondition(
@@ -1226,7 +1226,7 @@ func (r *OctaviaReconciler) redisCreateOrUpdate(
 
 func (r *OctaviaReconciler) amphoraControllerDaemonSetCreateOrUpdate(
 	instance *octaviav1.Octavia,
-	tenantNetworkID string,
+	networkInfo octavia.NetworkProvisioningSummary,
 	controllerSpec octaviav1.OctaviaAmphoraControllerSpec,
 	role string,
 ) (*octaviav1.OctaviaAmphoraController,
@@ -1250,7 +1250,8 @@ func (r *OctaviaReconciler) amphoraControllerDaemonSetCreateOrUpdate(
 		daemonset.Spec.Secret = instance.Spec.Secret
 		daemonset.Spec.TransportURLSecret = instance.Status.TransportURLSecret
 		daemonset.Spec.ServiceAccount = instance.RbacResourceName()
-		daemonset.Spec.LbMgmtNetworkID = tenantNetworkID
+		daemonset.Spec.LbMgmtNetworkID = networkInfo.TenantNetworkID
+		daemonset.Spec.LbSecurityGroupID = networkInfo.SecurityGroupID
 		daemonset.Spec.AmphoraCustomFlavors = instance.Spec.AmphoraCustomFlavors
 		daemonset.Spec.RedisHostIPs = instance.Status.RedisHostIPs
 		if len(daemonset.Spec.NodeSelector) == 0 {

--- a/templates/octaviaamphoracontroller/config/octavia.conf
+++ b/templates/octaviaamphoracontroller/config/octavia.conf
@@ -36,6 +36,7 @@ server_ca = /etc/octavia/certs/server_ca.cert.pem
 [controller_worker]
 amp_boot_network_list={{ .LbMgmtNetworkId }}
 amp_flavor_id={{ .AmpFlavorId }}
+amp_secgroup_list={{ .LbSecurityGroupId }}
 amp_image_tag=amphora-image
 amp_ssh_key_name={{ .NovaSshKeyPair }}
 controller_ip_port_list={{ .ControllerIPList }}


### PR DESCRIPTION
The amphora controller's require the security group id in the configuration.

(patch also adds security group rules for log offloading over tcp that
 were missing from previous commits)