### PR TITLE
Change Apache server listening port

### DIFF
--- a/controllers/octavia_controller.go
+++ b/controllers/octavia_controller.go
@@ -44,6 +44,7 @@ import (
 	octaviav1 "github.com/openstack-k8s-operators/octavia-operator/api/v1beta1"
 	"github.com/openstack-k8s-operators/octavia-operator/pkg/octavia"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
 
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
@@ -926,9 +927,10 @@ func (r *OctaviaReconciler) reconcileAmphoraImages(
 			Selector:  serviceLabels,
 			Ports: []corev1.ServicePort{
 				{
-					Name:     "octavia-image-upload-internal",
-					Port:     octavia.ApacheInternalPort,
-					Protocol: corev1.ProtocolTCP,
+					Name:       "octavia-image-upload-internal",
+					Port:       octavia.ApacheInternalPort,
+					TargetPort: intstr.FromInt(8080),
+					Protocol:   corev1.ProtocolTCP,
 				},
 			},
 		}),
@@ -1081,7 +1083,6 @@ func (r *OctaviaReconciler) generateServiceConfigMaps(
 		),
 	}
 	templateParameters["ServiceUser"] = instance.Spec.ServiceUser
-	templateParameters["ApachePort"] = octavia.ApacheInternalPort
 
 	cms := []util.Template{
 		// ScriptsConfigMap

--- a/templates/octavia/config/httpd.conf
+++ b/templates/octavia/config/httpd.conf
@@ -39,7 +39,7 @@ ServerRoot "/etc/httpd"
 # prevent Apache from glomming onto all bound IP addresses.
 #
 #Listen 12.34.56.78:80
-Listen [::]:{{.ApachePort}}
+Listen [::]:8080
 
 #
 # Dynamic Shared Object (DSO) Support


### PR DESCRIPTION
In the container, apache doesn't start when using port 80 (permission issue) but the service needs to be on port 80, glance doesn't accept any other ports than standard ports (80 or 443).