### PR TITLE
Fix a couple of router related issues.

### DIFF
--- a/pkg/octavia/lb_mgmt_network.go
+++ b/pkg/octavia/lb_mgmt_network.go
@@ -250,7 +250,7 @@ func ensureNetworkExt(client *gophercloud.ServiceClient, createOpts networks.Cre
 		segment := []provider.Segment{
 			{
 				NetworkType:     "flat",
-				PhysicalNetwork: "br-octavia",
+				PhysicalNetwork: LbProvPhysicalNet,
 			},
 		}
 
@@ -469,7 +469,7 @@ func reconcileRouter(client *gophercloud.ServiceClient, router *routers.Router,
 	//
 	gatewayInfo := router.GatewayInfo
 	if gatewayNetwork.ID != gatewayInfo.NetworkID || *gatewayInfo.EnableSNAT ||
-		compareExternalFixedIPs(gatewayInfo.ExternalFixedIPs, fixedIPs) {
+		!compareExternalFixedIPs(gatewayInfo.ExternalFixedIPs, fixedIPs) {
 		gwInfo := routers.GatewayInfo{
 			NetworkID:        gatewayNetwork.ID,
 			EnableSNAT:       &enableSNAT,

--- a/pkg/octavia/network_consts.go
+++ b/pkg/octavia/network_consts.go
@@ -89,7 +89,7 @@ const (
 	LbProvSubnetCIDR = "172.23.0.0/24"
 
 	// LbProvSubnetAllocationPoolStart -
-	LbProvSubnetAllocationPoolStart = "172.23.0.5"
+	LbProvSubnetAllocationPoolStart = "172.23.0.10"
 
 	// LbProvSubnetAllocationPoolEnd -
 	LbProvSubnetAllocationPoolEnd = "172.23.0.25"
@@ -101,11 +101,8 @@ const (
 	// LbRouterName -
 	LbRouterName = "octavia-link-router"
 
-	// LbProvBridgeName -
-	LbProvBridgeName = "br-octavia"
-
-	// LbProvNetAttachName -
-	LbProvNetAttachName = "octavia"
+	// LbProvPhysicalNet -
+	LbProvPhysicalNet = "octavia"
 
 	// LbRouterFixedIPAddress
 	LbRouterFixedIPAddress = "172.23.0.5"


### PR DESCRIPTION
Add missing negation of compare when reconciling router gateway info and change the start of the provider network's subnet allocation pool to avoid conflicts between the router's fixed IP address and the ovnmetadata agent.