### PR TITLE
Remove serviceAccount from Octavia

### DIFF
--- a/api/bases/octavia.openstack.org_octavias.yaml
+++ b/api/bases/octavia.openstack.org_octavias.yaml
@@ -1164,10 +1164,6 @@ spec:
                 description: Secret containing OpenStack password information for
                   octavia's keystone password; no longer used for database password
                 type: string
-              serviceAccount:
-                description: ServiceAccount - service account name used internally
-                  to provide Octavia services the default SA name
-                type: string
               serviceUser:
                 default: octavia
                 description: ServiceUser - service user name
@@ -1186,7 +1182,7 @@ spec:
               tenantName:
                 default: service
                 description: TenantName - the name of the OpenStack tenant that controls
-                  the Octavia resources TODO(gthiemonge) same as ServiceAccount?
+                  the Octavia resources
                 type: string
             required:
             - apacheContainerImage
@@ -1194,7 +1190,6 @@ spec:
             - octaviaAPI
             - rabbitMqClusterName
             - secret
-            - serviceAccount
             type: object
           status:
             description: OctaviaStatus defines the observed state of Octavia

--- a/api/v1beta1/octavia_types.go
+++ b/api/v1beta1/octavia_types.go
@@ -158,7 +158,6 @@ type OctaviaSpecBase struct {
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:default=service
 	// TenantName - the name of the OpenStack tenant that controls the Octavia resources
-	// TODO(gthiemonge) same as ServiceAccount?
 	TenantName string `json:"tenantName"`
 
 	// +kubebuilder:validation:Optional
@@ -181,10 +180,6 @@ type OctaviaSpecBase struct {
 	// +kubebuilder:default={}
 	// AmphoraCustomFlavors - User-defined flavors for Octavia
 	AmphoraCustomFlavors []OctaviaAmphoraFlavor `json:"amphoraCustomFlavors,omitempty"`
-
-	// +kubebuilder:validation:Required
-	// ServiceAccount - service account name used internally to provide Octavia services the default SA name
-	ServiceAccount string `json:"serviceAccount"`
 
 	// +kubebuilder:validation:Optional
 	// Resources - Compute Resources required by this service (Limits/Requests).

--- a/config/crd/bases/octavia.openstack.org_octavias.yaml
+++ b/config/crd/bases/octavia.openstack.org_octavias.yaml
@@ -1164,10 +1164,6 @@ spec:
                 description: Secret containing OpenStack password information for
                   octavia's keystone password; no longer used for database password
                 type: string
-              serviceAccount:
-                description: ServiceAccount - service account name used internally
-                  to provide Octavia services the default SA name
-                type: string
               serviceUser:
                 default: octavia
                 description: ServiceUser - service user name
@@ -1186,7 +1182,7 @@ spec:
               tenantName:
                 default: service
                 description: TenantName - the name of the OpenStack tenant that controls
-                  the Octavia resources TODO(gthiemonge) same as ServiceAccount?
+                  the Octavia resources
                 type: string
             required:
             - apacheContainerImage
@@ -1194,7 +1190,6 @@ spec:
             - octaviaAPI
             - rabbitMqClusterName
             - secret
-            - serviceAccount
             type: object
           status:
             description: OctaviaStatus defines the observed state of Octavia


### PR DESCRIPTION
serviceAccount is not used in Octavia (only used in AmphoraControllers and API)..