### PR TITLE
Remove hw_architecture property from images

### DIFF
--- a/pkg/octavia/images.go
+++ b/pkg/octavia/images.go
@@ -88,8 +88,10 @@ func ensureAmphoraImage(
 			ContainerFormat: "bare",
 			DiskFormat:      "qcow2",
 			Properties: map[string]string{
-				"hw_architecture": "x86_64",
-				"image_checksum":  amphoraImage.Checksum,
+				// TODO(gthiemonge) hw_architecture is not set due to a bug in
+				// placement/nova (OSPRH-6215)
+				//"hw_architecture": "x86_64",
+				"image_checksum": amphoraImage.Checksum,
 			},
 		}
 


### PR DESCRIPTION
Because of a bug in nova (https://issues.redhat.com/browse/OSPRH-6215), the hw_architecture property cannot be used, it needs to be reenabled when the bug is fixed.

Jira: [OSPRH-6402](https://issues.redhat.com//browse/OSPRH-6402)