### PR TITLE
Set termination grace period for Amphora controllers

### DIFF
--- a/templates/octaviaamphoracontroller/config/octavia.conf
+++ b/templates/octaviaamphoracontroller/config/octavia.conf
@@ -1,6 +1,10 @@
 [DEFAULT]
 debug=True
 rpc_response_timeout=60
+# Long timeout until jobboard is used
+# TODO(gthiemonge) This setting must be updated/removed when Jobboard is
+# re-enabled
+graceful_shutdown_timeout=600
 [api_settings]
 [database]
 connection = {{ .DatabaseConnection }}


### PR DESCRIPTION
Since Redis was removed, the octavia-operator must carefuly handle the graceful shutdown of the octavia amphora controllers, if the pods are killed while the controllers are still processing work, some resources may be stuck or leak.

To prevent such issues, use a long termination period for the pods, and set [DEFAULT].graceful_shutdown_timeout accordinly in the services.

Jira: [OSPRH-6463](https://issues.redhat.com//browse/OSPRH-6463)