### PR TITLE
Ensure golangci-lint runs on all files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -69,5 +69,5 @@ repos:
 - repo: https://github.com/golangci/golangci-lint
   rev: v1.55.2
   hooks:
-    - id: golangci-lint
+    - id: golangci-lint-full
       args: ["-v"]

--- a/controllers/octaviaapi_controller.go
+++ b/controllers/octaviaapi_controller.go
@@ -32,7 +32,6 @@ import (
 	"github.com/openstack-k8s-operators/lib-common/modules/common/helper"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/labels"
 	nad "github.com/openstack-k8s-operators/lib-common/modules/common/networkattachment"
-	"github.com/openstack-k8s-operators/lib-common/modules/common/secret"
 	oko_secret "github.com/openstack-k8s-operators/lib-common/modules/common/secret"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/service"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/tls"
@@ -280,7 +279,7 @@ func (r *OctaviaAPIReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Ma
 func (r *OctaviaAPIReconciler) findObjectsForSrc(ctx context.Context, src client.Object) []reconcile.Request {
 	requests := []reconcile.Request{}
 
-	l := log.FromContext(context.Background()).WithName("Controllers").WithName("OctaviaAPI")
+	l := log.FromContext(ctx).WithName("Controllers").WithName("OctaviaAPI")
 
 	for _, field := range allWatchFields {
 		crList := &octaviav1.OctaviaAPIList{}
@@ -288,7 +287,7 @@ func (r *OctaviaAPIReconciler) findObjectsForSrc(ctx context.Context, src client
 			FieldSelector: fields.OneTermEqualSelector(field, src.GetName()),
 			Namespace:     src.GetNamespace(),
 		}
-		err := r.Client.List(context.TODO(), crList, listOps)
+		err := r.Client.List(ctx, crList, listOps)
 		if err != nil {
 			return []reconcile.Request{}
 		}
@@ -531,7 +530,7 @@ func (r *OctaviaAPIReconciler) reconcileInit(
 	return ctrlResult, nil
 }
 
-func (r *OctaviaAPIReconciler) reconcileUpdate(ctx context.Context, instance *octaviav1.OctaviaAPI, helper *helper.Helper) (ctrl.Result, error) {
+func (r *OctaviaAPIReconciler) reconcileUpdate(ctx context.Context) (ctrl.Result, error) {
 	Log := r.GetLogger(ctx)
 	Log.Info("Reconciling Service update")
 
@@ -542,7 +541,7 @@ func (r *OctaviaAPIReconciler) reconcileUpdate(ctx context.Context, instance *oc
 	return ctrl.Result{}, nil
 }
 
-func (r *OctaviaAPIReconciler) reconcileUpgrade(ctx context.Context, instance *octaviav1.OctaviaAPI, helper *helper.Helper) (ctrl.Result, error) {
+func (r *OctaviaAPIReconciler) reconcileUpgrade(ctx context.Context) (ctrl.Result, error) {
 	Log := r.GetLogger(ctx)
 	Log.Info("Reconciling Service upgrade")
 
@@ -739,7 +738,7 @@ func (r *OctaviaAPIReconciler) reconcileNormal(ctx context.Context, instance *oc
 	}
 
 	// Handle service update
-	ctrlResult, err = r.reconcileUpdate(ctx, instance, helper)
+	ctrlResult, err = r.reconcileUpdate(ctx)
 	if err != nil {
 		return ctrlResult, err
 	} else if (ctrlResult != ctrl.Result{}) {
@@ -747,7 +746,7 @@ func (r *OctaviaAPIReconciler) reconcileNormal(ctx context.Context, instance *oc
 	}
 
 	// Handle service upgrade
-	ctrlResult, err = r.reconcileUpgrade(ctx, instance, helper)
+	ctrlResult, err = r.reconcileUpgrade(ctx)
 	if err != nil {
 		return ctrlResult, err
 	} else if (ctrlResult != ctrl.Result{}) {
@@ -999,7 +998,7 @@ func (r *OctaviaAPIReconciler) generateServiceConfigMaps(
 			Labels:        cmLabels,
 		},
 	}
-	err = secret.EnsureSecrets(ctx, h, instance, cms, envVars)
+	err = oko_secret.EnsureSecrets(ctx, h, instance, cms, envVars)
 
 	if err != nil {
 		Log.Error(err, "unable to process config map")

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -20,8 +20,8 @@ import (
 	"path/filepath"
 	"testing"
 
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
+	. "github.com/onsi/ginkgo/v2" //revive:disable:dot-imports
+	. "github.com/onsi/gomega"    //revive:disable:dot-imports
 
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"

--- a/pkg/octavia/amphora_certs.go
+++ b/pkg/octavia/amphora_certs.go
@@ -113,7 +113,7 @@ func generateCACert(caPrivKey *rsa.PrivateKey, commonName string) ([]byte, *x509
 }
 
 // Create a certificate and key for the client and sign it with the CA
-func generateClientCert(caCertPEM []byte, caTemplate *x509.Certificate, certPrivKey *rsa.PrivateKey, caPrivKey *rsa.PrivateKey, commonName string) ([]byte, error) {
+func generateClientCert(caTemplate *x509.Certificate, certPrivKey *rsa.PrivateKey, caPrivKey *rsa.PrivateKey, commonName string) ([]byte, error) {
 
 	certTemplate := &x509.Certificate{
 		SerialNumber:          big.NewInt(2019),
@@ -152,7 +152,7 @@ func EnsureAmphoraCerts(
 	h *helper.Helper,
 	log *logr.Logger) error {
 	var oAmpSecret *corev1.Secret
-	var serverCAPass []byte = nil
+	var serverCAPass []byte
 
 	certsSecretName := fmt.Sprintf("%s-certs-secret", instance.Name)
 	_, _, err := secret.GetSecret(ctx, h, certsSecretName, instance.Namespace)
@@ -192,7 +192,7 @@ func EnsureAmphoraCerts(
 		if err != nil {
 			return fmt.Errorf("Error while generating amphora client key: %w", err)
 		}
-		clientCert, err := generateClientCert(clientCACert, clientCATemplate, clientKey, clientCAKey, "Octavia controller")
+		clientCert, err := generateClientCert(clientCATemplate, clientKey, clientCAKey, "Octavia controller")
 		if err != nil {
 			return fmt.Errorf("Error while generating amphora client certificate: %w", err)
 		}

--- a/pkg/octavia/amphora_ssh.go
+++ b/pkg/octavia/amphora_ssh.go
@@ -24,7 +24,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/go-logr/logr"
 	"github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/keypairs"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/configmap"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/helper"
@@ -141,7 +140,7 @@ func uploadKeypair(
 		return fmt.Errorf("Could not extract keypairs: %w", err)
 	}
 
-	var keypairExists bool = false
+	var keypairExists = false
 	for _, kp := range allKeyPairs {
 		if kp.Name == NovaKeyPairName {
 			keypairExists = true
@@ -177,7 +176,6 @@ func EnsureAmpSSHConfig(
 	ctx context.Context,
 	instance *octaviav1.Octavia,
 	h *helper.Helper,
-	log *logr.Logger,
 ) error {
 	cmap, _, err := configmap.GetConfigMap(
 		ctx, h, instance, instance.Spec.LoadBalancerSSHPubKey, 10*time.Second)

--- a/pkg/octavia/image_upload_deployment.go
+++ b/pkg/octavia/image_upload_deployment.go
@@ -67,7 +67,7 @@ func getInitVolumeMounts() []corev1.VolumeMount {
 }
 
 // GetVolumeMounts - general VolumeMounts
-func getVolumeMounts(serviceName string) []corev1.VolumeMount {
+func getVolumeMounts() []corev1.VolumeMount {
 	return []corev1.VolumeMount{
 		{
 			Name:      "amphora-image",
@@ -116,7 +116,7 @@ func ImageUploadDeployment(
 							},
 							Args:         args,
 							Image:        instance.Spec.ApacheContainerImage,
-							VolumeMounts: getVolumeMounts("octavia-image-upload"),
+							VolumeMounts: getVolumeMounts(),
 							Resources:    instance.Spec.Resources,
 							// TODO(gthiemonge) do we need probes?
 						},

--- a/pkg/octavia/images.go
+++ b/pkg/octavia/images.go
@@ -34,7 +34,7 @@ const (
 	AmphoraImageVertTag = "amphora-image-vert"
 )
 
-type OctaviaAmphoraImage struct {
+type AmphoraImage struct {
 	ID       string
 	URL      string
 	Checksum string
@@ -73,7 +73,7 @@ func getTags(
 func ensureAmphoraImage(
 	imageClient *gophercloud.ServiceClient,
 	log *logr.Logger,
-	amphoraImage OctaviaAmphoraImage,
+	amphoraImage AmphoraImage,
 	imageStatus string,
 ) (bool, error) {
 	log.Info(fmt.Sprintf("Ensuring image %+v", amphoraImage.Name))
@@ -131,7 +131,7 @@ func amphoraImageListByTag(
 	imageClient *gophercloud.ServiceClient,
 	log *logr.Logger,
 	tag string,
-) (map[string]OctaviaAmphoraImage, error) {
+) (map[string]AmphoraImage, error) {
 	listOpts := images.ListOpts{
 		Sort: "created_at:desc",
 		Tags: []string{tag},
@@ -147,7 +147,7 @@ func amphoraImageListByTag(
 		return nil, err
 	}
 
-	existingAmphoraImages := map[string]OctaviaAmphoraImage{}
+	existingAmphoraImages := map[string]AmphoraImage{}
 	for _, image := range allImages {
 		var checksum string
 		prop := image.Properties["image_checksum"]
@@ -159,7 +159,7 @@ func amphoraImageListByTag(
 		if _, ok := existingAmphoraImages[image.Name]; ok {
 			log.Info(fmt.Sprintf("Multiple '%s' images exist. The Octavia service uses only the most recent image", image.Name))
 		} else {
-			existingAmphoraImages[image.Name] = OctaviaAmphoraImage{
+			existingAmphoraImages[image.Name] = AmphoraImage{
 				ID:       image.ID,
 				Name:     image.Name,
 				Status:   image.Status,
@@ -174,7 +174,7 @@ func amphoraImageListByTag(
 func amphoraImageList(
 	imageClient *gophercloud.ServiceClient,
 	log *logr.Logger,
-) (map[string]OctaviaAmphoraImage, error) {
+) (map[string]AmphoraImage, error) {
 	amphoraImages, err := amphoraImageListByTag(imageClient, log, AmphoraImageTag)
 	if err != nil {
 		return nil, err
@@ -196,7 +196,7 @@ func EnsureAmphoraImages(
 	instance *octaviav1.Octavia,
 	log *logr.Logger,
 	helper *helper.Helper,
-	imageList []OctaviaAmphoraImage,
+	imageList []AmphoraImage,
 ) (bool, error) {
 	osclient, err := getOpenstackClient(ctx, instance, helper)
 	if err != nil {
@@ -242,7 +242,6 @@ func EnsureAmphoraImages(
 func GetImageOwnerID(
 	ctx context.Context,
 	instance *octaviav1.Octavia,
-	log *logr.Logger,
 	helper *helper.Helper,
 ) (string, error) {
 	osclient, err := getOpenstackClient(ctx, instance, helper)

--- a/pkg/octavia/lb_mgmt_network.go
+++ b/pkg/octavia/lb_mgmt_network.go
@@ -46,7 +46,7 @@ type NetworkProvisioningSummary struct {
 // status.
 //
 
-func findPort(client *gophercloud.ServiceClient, portName string, networkID string, ipAddress string, log *logr.Logger) (*ports.Port, error) {
+func findPort(client *gophercloud.ServiceClient, networkID string, ipAddress string, log *logr.Logger) (*ports.Port, error) {
 	listOpts := ports.ListOpts{
 		NetworkID: networkID,
 	}
@@ -78,7 +78,7 @@ func ensurePort(client *gophercloud.ServiceClient, tenantNetwork *networks.Netwo
 		ipAddress = LbMgmtRouterPortIPv6
 	}
 
-	p, err := findPort(client, LbMgmtRouterPortName, tenantNetwork.ID, ipAddress, log)
+	p, err := findPort(client, tenantNetwork.ID, ipAddress, log)
 	if err != nil {
 		return nil, err
 	}
@@ -314,7 +314,7 @@ func ensureProvSubnet(client *gophercloud.ServiceClient, providerNetwork *networ
 
 func ensureProvNetwork(client *gophercloud.ServiceClient, serviceTenantID string, log *logr.Logger) (
 	*networks.Network, error) {
-	provNet, err := getNetwork(client, LbProvNetName, serviceTenantID)
+	_, err := getNetwork(client, LbProvNetName, serviceTenantID)
 	if err != nil {
 		return nil, err
 	}
@@ -326,7 +326,7 @@ func ensureProvNetwork(client *gophercloud.ServiceClient, serviceTenantID string
 		AdminStateUp: &asu,
 		TenantID:     serviceTenantID,
 	}
-	provNet, err = ensureNetworkExt(client, createOpts, log, serviceTenantID)
+	provNet, err := ensureNetworkExt(client, createOpts, log, serviceTenantID)
 	if err != nil {
 		return nil, err
 	}
@@ -422,7 +422,7 @@ func ensureLbMgmtNetwork(client *gophercloud.ServiceClient, networkDetails *octa
 
 func externalFixedIPs(subnetID string) []routers.ExternalFixedIP {
 	ips := []routers.ExternalFixedIP{
-		routers.ExternalFixedIP{
+		{
 			IPAddress: LbRouterFixedIPAddress,
 			SubnetID:  subnetID,
 		},

--- a/pkg/octavia/quotas.go
+++ b/pkg/octavia/quotas.go
@@ -28,10 +28,7 @@ import (
 )
 
 func ensureComputeQuotas(
-	ctx context.Context,
-	instance *octaviav1.Octavia,
 	log *logr.Logger,
-	helper *helper.Helper,
 	osclient *openstack.OpenStack,
 	serviceTenantID string,
 ) error {
@@ -72,10 +69,7 @@ func ensureComputeQuotas(
 }
 
 func ensureNetworkQuotas(
-	ctx context.Context,
-	instance *octaviav1.Octavia,
 	log *logr.Logger,
-	helper *helper.Helper,
 	osclient *openstack.OpenStack,
 	serviceTenantID string,
 ) error {
@@ -129,10 +123,10 @@ func EnsureQuotas(
 		return fmt.Errorf("error while getting the project %s: %w", instance.Spec.TenantName, err)
 	}
 
-	if err := ensureComputeQuotas(ctx, instance, log, helper, osclient, serviceTenant.ID); err != nil {
+	if err := ensureComputeQuotas(log, osclient, serviceTenant.ID); err != nil {
 		return fmt.Errorf("error while setting the compute quotas: %w", err)
 	}
-	if err := ensureNetworkQuotas(ctx, instance, log, helper, osclient, serviceTenant.ID); err != nil {
+	if err := ensureNetworkQuotas(log, osclient, serviceTenant.ID); err != nil {
 		return fmt.Errorf("error while setting the network quotas: %w", err)
 	}
 


### PR DESCRIPTION
* removed unused func params and imports
* ignore revive dot-imports rule on ginkgo and gomega as dot import
there is the recommended practice
* added missing error handling
* various small style fixes found by the linter
