### PR TITLE
Add OVN DB TLS Certificates to driver agent

### DIFF
--- a/templates/octaviaapi/config/octavia-driver-agent-config.json
+++ b/templates/octaviaapi/config/octavia-driver-agent-config.json
@@ -12,6 +12,22 @@
             "dest": "/etc/octavia/octavia.conf.d/custom.conf",
             "owner": "octavia",
             "perm": "0600"
+        },
+        {
+            "source": "/var/lib/config-data/tls/certs/*",
+            "dest": "/etc/pki/tls/certs/",
+            "owner": "octavia",
+            "perm": "0440",
+            "optional": true,
+            "merge": true
+        },
+        {
+            "source": "/var/lib/config-data/tls/private/*",
+            "dest": "/etc/pki/tls/private/",
+            "owner": "octavia",
+            "perm": "0400",
+            "optional": true,
+            "merge": true
         }
     ],
     "permissions": [

--- a/tests/kuttl/tests/octavia_tls/02-assert.yaml
+++ b/tests/kuttl/tests/octavia_tls/02-assert.yaml
@@ -198,6 +198,26 @@ spec:
           name: config-data
         - mountPath: /run/octavia
           name: octavia-run
+        - mountPath: /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
+          name: combined-ca-bundle
+          readOnly: true
+          subPath: tls-ca-bundle.pem
+        - mountPath: /var/lib/config-data/tls/certs/internal.crt
+          name: internal-tls-certs
+          readOnly: true
+          subPath: tls.crt
+        - mountPath: /var/lib/config-data/tls/private/internal.key
+          name: internal-tls-certs
+          readOnly: true
+          subPath: tls.key
+        - mountPath: /var/lib/config-data/tls/certs/public.crt
+          name: public-tls-certs
+          readOnly: true
+          subPath: tls.crt
+        - mountPath: /var/lib/config-data/tls/private/public.key
+          name: public-tls-certs
+          readOnly: true
+          subPath: tls.key
       initContainers:
       - args:
         - -c


### PR DESCRIPTION
Driver agent also needs the OVN DB certificates in case we are using a TLS connection. This patch add those certificates as same way is done for the octavia-api

Jira: [OSPRH-7370](https://issues.redhat.com//browse/OSPRH-7370)
Signed-off-by: Fernando Royo <froyo@redhat.com>