### PR TITLE
Fix missing config for policy file override

### DIFF
--- a/templates/octaviaapi/config/octavia-api-config.json
+++ b/templates/octaviaapi/config/octavia-api-config.json
@@ -40,6 +40,13 @@
             "perm": "0400",
             "optional": true,
             "merge": true
+          },
+          {
+            "source": "/var/lib/config-data/merged/policy.yaml",
+            "dest": "/etc/octavia/policy.yaml",
+            "owner": "octavia",
+            "perm": "0600",
+            "optional": true
           }
     ],
     "permissions": [


### PR DESCRIPTION
When customizing the policy file throught defaultConfigOverwrite, the file must be explicity included in octavia-api-config.json, so it is copied to the correct path with the right ownership/permissions

Jira: [OSPRH-7228](https://issues.redhat.com//browse/OSPRH-7228)