### PR TITLE
Set verbosity level for debug logs

### DIFF
--- a/api/v1beta1/octavia_webhook.go
+++ b/api/v1beta1/octavia_webhook.go
@@ -47,7 +47,7 @@ var octavialog = logf.Log.WithName("octavia-resource")
 // SetupOctaviaDefaults - initialize Octavia spec defaults for use with either internal or external webhooks
 func SetupOctaviaDefaults(defaults OctaviaDefaults) {
 	octaviaDefaults = defaults
-	octavialog.Info("Octavia defaults initialized", "defaults", defaults)
+	octavialog.V(1).Info("Octavia defaults initialized", "defaults", defaults)
 }
 
 // SetupWebhookWithManager sets up the webhook with the Manager
@@ -63,7 +63,7 @@ var _ webhook.Defaulter = &Octavia{}
 
 // Default implements webhook.Defaulter so a webhook will be registered for the type
 func (r *Octavia) Default() {
-	octavialog.Info("default", "name", r.Name)
+	octavialog.V(1).Info("default", "name", r.Name)
 
 	r.Spec.Default()
 }
@@ -99,7 +99,7 @@ var _ webhook.Validator = &Octavia{}
 
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type
 func (r *Octavia) ValidateCreate() (admission.Warnings, error) {
-	octavialog.Info("validate create", "name", r.Name)
+	octavialog.V(1).Info("validate create", "name", r.Name)
 
 	var allErrs field.ErrorList
 	basePath := field.NewPath("spec")
@@ -142,7 +142,7 @@ func (r *OctaviaSpecCore) ValidateCreate(basePath *field.Path) field.ErrorList {
 
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
 func (r *Octavia) ValidateUpdate(old runtime.Object) (admission.Warnings, error) {
-	octavialog.Info("validate update", "name", r.Name)
+	octavialog.V(1).Info("validate update", "name", r.Name)
 
 	oldOctavia, ok := old.(*Octavia)
 	if !ok || oldOctavia == nil {

--- a/controllers/amphoracontroller_controller.go
+++ b/controllers/amphoracontroller_controller.go
@@ -186,32 +186,32 @@ func (r *OctaviaAmphoraControllerReconciler) Reconcile(ctx context.Context, req 
 func (r *OctaviaAmphoraControllerReconciler) reconcileDelete(ctx context.Context, instance *octaviav1.OctaviaAmphoraController,
 	helper *helper.Helper) (ctrl.Result, error) {
 	Log := r.GetLogger(ctx)
-	Log.Info("Reconciling Service delete")
+	Log.V(1).Info("Reconciling Service delete")
 
 	controllerutil.RemoveFinalizer(instance, helper.GetFinalizer())
 
-	Log.Info("Reconciled Service delete successfully")
+	Log.V(1).Info("Reconciled Service delete successfully")
 	return ctrl.Result{}, nil
 }
 
 func (r *OctaviaAmphoraControllerReconciler) reconcileUpdate(ctx context.Context) (ctrl.Result, error) {
 	Log := r.GetLogger(ctx)
-	Log.Info("Reconciling Service update")
-	Log.Info("Reconciled Service update successfully")
+	Log.V(1).Info("Reconciling Service update")
+	Log.V(1).Info("Reconciled Service update successfully")
 	return ctrl.Result{}, nil
 }
 
 func (r *OctaviaAmphoraControllerReconciler) reconcileUpgrade(ctx context.Context) (ctrl.Result, error) {
 	Log := r.GetLogger(ctx)
-	Log.Info("Reconciling Service upgrade")
-	Log.Info("Reconciled Service upgrade successfully")
+	Log.V(1).Info("Reconciling Service upgrade")
+	Log.V(1).Info("Reconciled Service upgrade successfully")
 	return ctrl.Result{}, nil
 }
 
 func (r *OctaviaAmphoraControllerReconciler) reconcileNormal(ctx context.Context, instance *octaviav1.OctaviaAmphoraController,
 	helper *helper.Helper) (ctrl.Result, error) {
 	Log := r.GetLogger(ctx)
-	Log.Info("Reconciling Service")
+	Log.V(1).Info("Reconciling Service")
 
 	// Prepare NetworkAttachments first, it must be done before generating the
 	// configuration as the config uses IP addresses of the attachments.
@@ -305,7 +305,7 @@ func (r *OctaviaAmphoraControllerReconciler) reconcileNormal(ctx context.Context
 	if err != nil {
 		return ctrl.Result{}, err
 	}
-	r.Log.Info(fmt.Sprintf("Using default flavor \"%s\"", defaultFlavorID))
+	r.Log.V(1).Info(fmt.Sprintf("Using default flavor \"%s\"", defaultFlavorID))
 
 	templateVars := OctaviaTemplateVars{
 		LbMgmtNetworkID:        instance.Spec.LbMgmtNetworkID,
@@ -458,10 +458,11 @@ func (r *OctaviaAmphoraControllerReconciler) reconcileNormal(ctx context.Context
 	// We reached the end of the Reconcile, update the Ready condition based on
 	// the sub conditions
 	if instance.Status.Conditions.AllSubConditionIsTrue() {
+		Log.Info("Amphora controller is now ready.")
 		instance.Status.Conditions.MarkTrue(
 			condition.ReadyCondition, condition.ReadyMessage)
 	} else {
-		Log.Info("Not all conditions are ready for Amphora controller")
+		Log.V(1).Info("Not all conditions are ready for Amphora controller yet")
 	}
 	return ctrl.Result{}, nil
 }
@@ -474,7 +475,7 @@ func (r *OctaviaAmphoraControllerReconciler) generateServiceConfigMaps(
 	templateVars OctaviaTemplateVars,
 	ospSecret *corev1.Secret,
 ) error {
-	r.Log.Info(fmt.Sprintf("generating service config map for %s (%s)", instance.Name, instance.Kind))
+	r.Log.V(1).Info(fmt.Sprintf("generating service config map for %s (%s)", instance.Name, instance.Kind))
 	cmLabels := labels.GetLabels(instance, labels.GetGroupLabel(instance.ObjectMeta.Name), map[string]string{})
 	db, err := mariadbv1.GetDatabaseByNameAndAccount(ctx, helper, octavia.DatabaseName, instance.Spec.DatabaseAccount, instance.Namespace)
 	if err != nil {
@@ -642,8 +643,7 @@ func (r *OctaviaAmphoraControllerReconciler) generateServiceConfigMaps(
 		return err
 	}
 
-	r.Log.Info("Service config map generated")
-
+	r.Log.V(1).Info("Service config map generated")
 	return nil
 }
 

--- a/controllers/octavia_controller.go
+++ b/controllers/octavia_controller.go
@@ -429,35 +429,35 @@ func (r *OctaviaReconciler) reconcileInit(
 
 	// run octavia db sync - end
 
-	Log.Info("Reconciled Service init successfully")
+	Log.V(1).Info("Reconciled Service init successfully")
 	return ctrl.Result{}, nil
 }
 
 func (r *OctaviaReconciler) reconcileUpdate(ctx context.Context) (ctrl.Result, error) {
 	Log := r.GetLogger(ctx)
-	Log.Info("Reconciling Service update")
+	Log.V(1).Info("Reconciling Service update")
 
 	// TODO: should have minor update tasks if required
 	// - delete dbsync hash from status to rerun it?
 
-	Log.Info("Reconciled Service update successfully")
+	Log.V(1).Info("Reconciled Service update successfully")
 	return ctrl.Result{}, nil
 }
 
 func (r *OctaviaReconciler) reconcileUpgrade(ctx context.Context) (ctrl.Result, error) {
 	Log := r.GetLogger(ctx)
-	Log.Info("Reconciling Service upgrade")
+	Log.V(1).Info("Reconciling Service upgrade")
 
 	// TODO: should have major version upgrade tasks
 	// -delete dbsync hash from status to rerun it?
 
-	Log.Info("Reconciled Service upgrade successfully")
+	Log.V(1).Info("Reconciled Service upgrade successfully")
 	return ctrl.Result{}, nil
 }
 
 func (r *OctaviaReconciler) reconcileNormal(ctx context.Context, instance *octaviav1.Octavia, helper *helper.Helper) (ctrl.Result, error) {
 	Log := r.GetLogger(ctx)
-	Log.Info("Reconciling Service")
+	Log.V(1).Info("Reconciling Service")
 
 	// Service account, role, binding
 	rbacRules := []rbacv1.PolicyRule{

--- a/controllers/octaviaapi_controller.go
+++ b/controllers/octaviaapi_controller.go
@@ -361,7 +361,7 @@ func (r *OctaviaAPIReconciler) reconcileInit(
 	serviceLabels map[string]string,
 ) (ctrl.Result, error) {
 	Log := r.GetLogger(ctx)
-	Log.Info("Reconciling Service init")
+	Log.V(1).Info("Reconciling Service init")
 	//
 	// expose the service (create service and return the created endpoint URLs)
 	//
@@ -526,36 +526,36 @@ func (r *OctaviaAPIReconciler) reconcileInit(
 		instance.Status.Conditions.Set(c)
 	}
 
-	Log.Info("Reconciled Service init successfully")
+	Log.V(1).Info("Reconciled Service init successfully")
 	return ctrlResult, nil
 }
 
 func (r *OctaviaAPIReconciler) reconcileUpdate(ctx context.Context) (ctrl.Result, error) {
 	Log := r.GetLogger(ctx)
-	Log.Info("Reconciling Service update")
+	Log.V(1).Info("Reconciling Service update")
 
 	// TODO: should have minor update tasks if required
 	// - delete dbsync hash from status to rerun it?
 
-	Log.Info("Reconciled Service update successfully")
+	Log.V(1).Info("Reconciled Service update successfully")
 	return ctrl.Result{}, nil
 }
 
 func (r *OctaviaAPIReconciler) reconcileUpgrade(ctx context.Context) (ctrl.Result, error) {
 	Log := r.GetLogger(ctx)
-	Log.Info("Reconciling Service upgrade")
+	Log.V(1).Info("Reconciling Service upgrade")
 
 	// TODO: should have major version upgrade tasks
 	// -delete dbsync hash from status to rerun it?
 
-	Log.Info("Reconciled Service upgrade successfully")
+	Log.V(1).Info("Reconciled Service upgrade successfully")
 	return ctrl.Result{}, nil
 }
 
 // TODO(tweining): implement
 func (r *OctaviaAPIReconciler) reconcileNormal(ctx context.Context, instance *octaviav1.OctaviaAPI, helper *helper.Helper) (ctrl.Result, error) {
 	Log := r.GetLogger(ctx)
-	Log.Info("Reconciling Service")
+	Log.V(1).Info("Reconciling Service")
 
 	// ConfigMap
 	configMapVars := make(map[string]env.Setter)
@@ -836,7 +836,7 @@ func (r *OctaviaAPIReconciler) reconcileNormal(ctx context.Context, instance *oc
 		instance.Status.Conditions.MarkTrue(
 			condition.ReadyCondition, condition.ReadyMessage)
 	}
-	Log.Info("Reconciled Service successfully")
+	Log.V(1).Info("Reconciled Service successfully")
 	return ctrl.Result{}, nil
 }
 
@@ -849,7 +849,7 @@ func (r *OctaviaAPIReconciler) generateServiceConfigMaps(
 	envVars *map[string]env.Setter,
 ) error {
 	Log := r.GetLogger(ctx)
-	Log.Info("Generating service config map")
+	Log.V(1).Info("Generating service config map")
 	//
 	// create Configmap/Secret required for octavia input
 	// - %-scripts configmap holding scripts to e.g. bootstrap the service
@@ -1004,7 +1004,7 @@ func (r *OctaviaAPIReconciler) generateServiceConfigMaps(
 		Log.Error(err, "unable to process config map")
 		return err
 	}
-	Log.Info("Service config map generated")
+	Log.V(1).Info("Service config map generated")
 
 	return nil
 }

--- a/pkg/octavia/lb_mgmt_network.go
+++ b/pkg/octavia/lb_mgmt_network.go
@@ -847,12 +847,12 @@ func EnsureAmphoraManagementNetwork(
 		return NetworkProvisioningSummary{}, err
 	}
 	if router != nil {
-		log.Info("Router object found, reconciling")
+		log.V(1).Info("Router object found, reconciling")
 		router, err = reconcileRouter(client, router, providerNetwork, providerSubnet, networkParameters, log)
 		if err != nil {
 			return NetworkProvisioningSummary{}, err
 		}
-		log.Info(fmt.Sprintf("Reconciled router %s (%s)", router.Name, router.ID))
+		log.V(1).Info(fmt.Sprintf("Reconciled router %s (%s)", router.Name, router.ID))
 	} else {
 		log.Info("Creating octavia provider router")
 		enableSNAT := false


### PR DESCRIPTION
In order to be able to filter debug logs from other info logs, we should
use verbosity levels as described in[1].

[1]:
https://github.com/kubernetes/community/blob/master/contributors/devel/sig-instrumentation/logging.md#what-method-to-use