### PR TITLE
Add missing configuration directory

### DIFF
--- a/templates/octaviaamphoracontroller/bin/octavia_controller_start.sh
+++ b/templates/octaviaamphoracontroller/bin/octavia_controller_start.sh
@@ -25,4 +25,4 @@ fi
 # Ignore possible errors
 /usr/local/bin/container-scripts/octavia_status.py || true
 
-exec /usr/bin/$1 --config-file /usr/share/octavia/octavia-dist.conf --config-file /etc/octavia/octavia.conf
+exec /usr/bin/$1 --config-file /usr/share/octavia/octavia-dist.conf --config-file /etc/octavia/octavia.conf --config-dir /etc/octavia/octavia.conf.d/


### PR DESCRIPTION
Ensure that the custom.conf file is included when used.