### PR TITLE
Add some missing requeues for certain situations

### DIFF
--- a/controllers/octavia_controller.go
+++ b/controllers/octavia_controller.go
@@ -829,7 +829,7 @@ func (r *OctaviaReconciler) reconcileNormal(ctx context.Context, instance *octav
 	//
 	if octaviaHealthManager.Status.ReadyCount != octaviaHealthManager.Status.DesiredNumberScheduled {
 		Log.Info("Health managers are not ready. Housekeeping and Worker services pending")
-		return ctrl.Result{}, nil
+		return ctrl.Result{RequeueAfter: time.Duration(10) * time.Second}, nil
 	}
 
 	// Skip the other amphora controller pods until the health managers are all up and running.
@@ -1525,7 +1525,7 @@ func (r *OctaviaReconciler) checkAmphoraGeneration(
 		client.InNamespace(instance.Namespace),
 	}
 	if err := r.Client.List(context.Background(), amph, listOpts...); err != nil {
-		r.Log.Error(err, "Unable to retrieve OctaviaAPI %w")
+		r.Log.Error(err, "Unable to retrieve AmphoraController %w")
 		return false, err
 	}
 	for _, item := range amph.Items {


### PR DESCRIPTION
Octavia controller now requeues if the health managers aren't up yet and when the hashes in the status change which may be causing some pod flapping on startup.