### PR TITLE
Revert "Wait for DB writes to propagate (causality checks)"

### DIFF
--- a/templates/octavia/config/octavia.conf
+++ b/templates/octavia/config/octavia.conf
@@ -12,10 +12,6 @@ default_listener_tls_versions=TLSv1.2,TLSv1.3
 default_pool_tls_versions=TLSv1.2,TLSv1.3
 [database]
 connection = {{ .DatabaseConnection }}
-# Wait for writes to complete when doing a read, update, or insert
-# Relevant for multi-master deployments so that workers table works as intended
-# https://mariadb.com/docs/server/ref/mdb/system-variables/wsrep_sync_wait/
-mysql_wsrep_sync_wait = 7
 [health_manager]
 health_update_threads=4
 stats_update_threads=4

--- a/templates/octaviaamphoracontroller/config/octavia.conf
+++ b/templates/octaviaamphoracontroller/config/octavia.conf
@@ -8,10 +8,6 @@ graceful_shutdown_timeout=600
 [api_settings]
 [database]
 connection = {{ .DatabaseConnection }}
-# Wait for writes to complete when doing a read, update, or insert
-# Relevant for multi-master deployments so that workers table works as intended
-# https://mariadb.com/docs/server/ref/mdb/system-variables/wsrep_sync_wait/
-mysql_wsrep_sync_wait = 7
 [health_manager]
 heartbeat_key={{ .HeartbeatKey }}
 health_update_threads=4

--- a/templates/octaviaapi/config/octavia.conf
+++ b/templates/octaviaapi/config/octavia.conf
@@ -12,10 +12,6 @@ default_listener_tls_versions=TLSv1.2,TLSv1.3
 default_pool_tls_versions=TLSv1.2,TLSv1.3
 [database]
 connection = {{ .DatabaseConnection }}
-# Wait for writes to complete when doing a read, update, or insert
-# Relevant for multi-master deployments so that workers table works as intended
-# https://mariadb.com/docs/server/ref/mdb/system-variables/wsrep_sync_wait/
-mysql_wsrep_sync_wait = 7
 [health_manager]
 health_update_threads=4
 stats_update_threads=4


### PR DESCRIPTION
This reverts commit e17640cb87a49b22f380e73e79c6ff24604a72fb.

No longer needed because of https://github.com/openstack-k8s-operators/mariadb-operator/pull/229