### PR TITLE
Fix missing owns in octavia controller

### DIFF
--- a/controllers/octavia_controller.go
+++ b/controllers/octavia_controller.go
@@ -244,6 +244,7 @@ func (r *OctaviaReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Owns(&mariadbv1.MariaDBDatabase{}).
 		Owns(&mariadbv1.MariaDBAccount{}).
 		Owns(&octaviav1.OctaviaAPI{}).
+		Owns(&octaviav1.OctaviaAmphoraController{}).
 		Owns(&batchv1.Job{}).
 		Owns(&corev1.Secret{}).
 		Owns(&corev1.ConfigMap{}).


### PR DESCRIPTION
The Octavia controller was missing the Owns() field for the amphora controllers causing some amphora controller reconciliations to result in misconfigured pods.