### PR TITLE
Avoid unneeded reconciles

### DIFF
--- a/controllers/amphoracontroller_controller.go
+++ b/controllers/amphoracontroller_controller.go
@@ -19,6 +19,7 @@ package controllers
 import (
 	"context"
 	"fmt"
+	"sort"
 	"strings"
 	"time"
 
@@ -596,6 +597,8 @@ func (r *OctaviaAmphoraControllerReconciler) generateServiceConfigMaps(
 			rsyslogIPAddresses = append(rsyslogIPAddresses, fmt.Sprintf("%s:514", val))
 		}
 	}
+	sort.Strings(ipAddresses)
+	sort.Strings(rsyslogIPAddresses)
 	ipAddressString := strings.Join(ipAddresses, ",")
 	templateParameters["ControllerIPList"] = ipAddressString
 	templateParameters["AdminLogTargetList"] = strings.Join(rsyslogIPAddresses, ",")

--- a/pkg/octavia/volumes.go
+++ b/pkg/octavia/volumes.go
@@ -92,11 +92,5 @@ func GetVolumeMounts(serviceName string) []corev1.VolumeMount {
 			SubPath:   serviceName + "-config.json",
 			ReadOnly:  true,
 		},
-		{
-			Name:      "config-data",
-			MountPath: "/etc/my.cnf",
-			SubPath:   "my.cnf",
-			ReadOnly:  true,
-		},
 	}
 }

--- a/templates/octavia/config/db-sync-config.json
+++ b/templates/octavia/config/db-sync-config.json
@@ -6,6 +6,12 @@
             "dest": "/etc/octavia/octavia.conf",
             "owner": "octavia",
             "perm": "0600"
+        },
+        {
+            "source": "/var/lib/config-data/merged/my.cnf",
+            "dest": "/etc/my.cnf",
+            "owner": "octavia",
+            "perm": "0644"
         }
     ],
     "permissions": [

--- a/templates/octaviaamphoracontroller/config/octavia-healthmanager-config.json
+++ b/templates/octaviaamphoracontroller/config/octavia-healthmanager-config.json
@@ -12,6 +12,12 @@
             "dest": "/etc/octavia/octavia.conf.d/custom.conf",
             "owner": "octavia",
             "perm": "0600"
+        },
+        {
+            "source": "/var/lib/config-data/merged/my.cnf",
+            "dest": "/etc/my.cnf",
+            "owner": "octavia",
+            "perm": "0644"
         }
     ]
 }

--- a/templates/octaviaamphoracontroller/config/octavia-housekeeping-config.json
+++ b/templates/octaviaamphoracontroller/config/octavia-housekeeping-config.json
@@ -12,6 +12,12 @@
             "dest": "/etc/octavia/octavia.conf.d/custom.conf",
             "owner": "octavia",
             "perm": "0600"
+        },
+        {
+            "source": "/var/lib/config-data/merged/my.cnf",
+            "dest": "/etc/my.cnf",
+            "owner": "octavia",
+            "perm": "0644"
         }
     ]
 }

--- a/templates/octaviaamphoracontroller/config/octavia-worker-config.json
+++ b/templates/octaviaamphoracontroller/config/octavia-worker-config.json
@@ -12,6 +12,12 @@
             "dest": "/etc/octavia/octavia.conf.d/custom.conf",
             "owner": "octavia",
             "perm": "0600"
+        },
+        {
+            "source": "/var/lib/config-data/merged/my.cnf",
+            "dest": "/etc/my.cnf",
+            "owner": "octavia",
+            "perm": "0644"
         }
     ]
 }

--- a/templates/octaviaapi/config/octavia-api-config.json
+++ b/templates/octaviaapi/config/octavia-api-config.json
@@ -47,6 +47,12 @@
             "owner": "octavia",
             "perm": "0600",
             "optional": true
+          },
+          {
+            "source": "/var/lib/config-data/merged/my.cnf",
+            "dest": "/etc/my.cnf",
+            "owner": "octavia",
+            "perm": "0644"
           }
     ],
     "permissions": [

--- a/templates/octaviaapi/config/octavia-driver-agent-config.json
+++ b/templates/octaviaapi/config/octavia-driver-agent-config.json
@@ -28,6 +28,12 @@
             "perm": "0400",
             "optional": true,
             "merge": true
+        },
+        {
+            "source": "/var/lib/config-data/merged/my.cnf",
+            "dest": "/etc/my.cnf",
+            "owner": "octavia",
+            "perm": "0644"
         }
     ],
     "permissions": [

--- a/tests/kuttl/tests/octavia_tls/02-assert.yaml
+++ b/tests/kuttl/tests/octavia_tls/02-assert.yaml
@@ -135,8 +135,6 @@ spec:
           name: config-data-merged
           readOnly: true
           subPath: octavia-api-config.json
-        - mountPath: /etc/my.cnf
-          name: config-data
         - mountPath: /run/octavia
           name: octavia-run
         - mountPath: /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
@@ -194,8 +192,6 @@ spec:
           name: config-data-merged
           readOnly: true
           subPath: octavia-driver-agent-config.json
-        - mountPath: /etc/my.cnf
-          name: config-data
         - mountPath: /run/octavia
           name: octavia-run
         - mountPath: /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem


### PR DESCRIPTION
Fixed a potential race condition in the octavia amphora controllers, config-data is only mounted in the init container and my.cnf is mounted as a subpath of the config-data mount in the "main" container. It may trigger some errors because the config-data is unmounted when kubernetes tries to mount the subpath.
Copy my.cnf from the config-data-merged mount, using the json config file.

Always sort lists in the config files
When build the template variables for the config files, we cannot ensure
that we always build the lists in the same order, sort them to avoid
potential recreation of the pods.

JIRA: [OSPRH-9128](https://issues.redhat.com//browse/OSPRH-9128)