### PR TITLE
Pass credentials via volumes instead of env

### DIFF
--- a/controllers/octaviaapi_controller.go
+++ b/controllers/octaviaapi_controller.go
@@ -557,57 +557,8 @@ func (r *OctaviaAPIReconciler) reconcileNormal(ctx context.Context, instance *oc
 	Log := r.GetLogger(ctx)
 	Log.Info("Reconciling Service")
 
-	// ConfigMap
-	configMapVars := make(map[string]env.Setter)
-
-	//
-	// check for required OpenStack secret holding passwords for service/admin user and add hash to the vars map
-	//
-	ospSecret, hash, err := oko_secret.GetSecret(ctx, helper, instance.Spec.Secret, instance.Namespace)
-	if err != nil {
-		if k8s_errors.IsNotFound(err) {
-			Log.Info(fmt.Sprintf("OpenStack secret %s not found", instance.Spec.Secret))
-			instance.Status.Conditions.Set(condition.FalseCondition(
-				condition.InputReadyCondition,
-				condition.RequestedReason,
-				condition.SeverityInfo,
-				condition.InputReadyWaitingMessage))
-			return ctrl.Result{RequeueAfter: time.Duration(10) * time.Second}, nil
-		}
-		instance.Status.Conditions.Set(condition.FalseCondition(
-			condition.InputReadyCondition,
-			condition.ErrorReason,
-			condition.SeverityWarning,
-			condition.InputReadyErrorMessage,
-			err.Error()))
-		return ctrl.Result{}, err
-	}
-	configMapVars[ospSecret.Name] = env.SetValue(hash)
-
-	transportURLSecret, hash, err := oko_secret.GetSecret(ctx, helper, instance.Spec.TransportURLSecret, instance.Namespace)
-	if err != nil {
-		if k8s_errors.IsNotFound(err) {
-			Log.Info(fmt.Sprintf("TransportURL secret %s not found", instance.Spec.TransportURLSecret))
-			instance.Status.Conditions.Set(condition.FalseCondition(
-				condition.InputReadyCondition,
-				condition.RequestedReason,
-				condition.SeverityInfo,
-				condition.InputReadyWaitingMessage))
-			return ctrl.Result{RequeueAfter: time.Duration(10) * time.Second}, nil
-		}
-		instance.Status.Conditions.Set(condition.FalseCondition(
-			condition.InputReadyCondition,
-			condition.ErrorReason,
-			condition.SeverityWarning,
-			condition.InputReadyErrorMessage,
-			err.Error()))
-		return ctrl.Result{}, err
-	}
-	configMapVars[transportURLSecret.Name] = env.SetValue(hash)
-
-	instance.Status.Conditions.MarkTrue(condition.InputReadyCondition, condition.InputReadyMessage)
-
-	// run check OpenStack secret - end
+	// Secrets
+	secretsVars := make(map[string]env.Setter)
 
 	//
 	// TLS input validation
@@ -635,7 +586,7 @@ func (r *OctaviaAPIReconciler) reconcileNormal(ctx context.Context, instance *oc
 		}
 
 		if hash != "" {
-			configMapVars[tls.CABundleKey] = env.SetValue(hash)
+			secretsVars[tls.CABundleKey] = env.SetValue(hash)
 		}
 
 		// Validate API service certs secrets
@@ -652,23 +603,22 @@ func (r *OctaviaAPIReconciler) reconcileNormal(ctx context.Context, instance *oc
 			return ctrlResult, nil
 		}
 
-		configMapVars[tls.TLSHashName] = env.SetValue(certsHash)
+		secretsVars[tls.TLSHashName] = env.SetValue(certsHash)
 	}
 
 	// all cert input checks out so report InputReady
 	instance.Status.Conditions.MarkTrue(condition.TLSInputReadyCondition, condition.InputReadyMessage)
 
 	//
-	// Create ConfigMaps and Secrets required as input for the Service and calculate an overall hash of hashes
+	// Create Secrets required as input for the Service and calculate an overall hash of hashes
 	//
 
 	//
-	// create Configmap required for octavia input
-	// - %-scripts configmap holding scripts to e.g. bootstrap the service
-	// - %-config configmap holding minimal octavia config required to get the service up, user can add additional files to be added to the service
-	// - parameters which has passwords gets added from the OpenStack secret via the init container
+	// create Secrets required for octavia input
+	// - %-scripts secret holding scripts to e.g. bootstrap the service
+	// - %-config secret holding minimal octavia config required to get the service up, user can add additional files to be added to the service
 	//
-	err = r.generateServiceConfigMaps(ctx, instance, helper, &configMapVars)
+	err := r.generateServiceSecrets(ctx, instance, helper, &secretsVars)
 	if err != nil {
 		instance.Status.Conditions.Set(condition.FalseCondition(
 			condition.ServiceConfigReadyCondition,
@@ -683,7 +633,7 @@ func (r *OctaviaAPIReconciler) reconcileNormal(ctx context.Context, instance *oc
 	// create hash over all the different input resources to identify if any those changed
 	// and a restart/recreate is required.
 	//
-	inputHash, hashChanged, err := r.createHashOfInputHashes(ctx, instance, configMapVars)
+	inputHash, hashChanged, err := r.createHashOfInputHashes(ctx, instance, secretsVars)
 	if err != nil {
 		return ctrl.Result{}, err
 	} else if hashChanged {
@@ -843,24 +793,68 @@ func (r *OctaviaAPIReconciler) reconcileNormal(ctx context.Context, instance *oc
 	return ctrl.Result{}, nil
 }
 
-// generateServiceConfigMaps - create create configmaps which hold scripts and service configuration
+// generateServiceSecrets - create creates which hold scripts and service configuration
 // TODO add DefaultConfigOverwrite
-func (r *OctaviaAPIReconciler) generateServiceConfigMaps(
+func (r *OctaviaAPIReconciler) generateServiceSecrets(
 	ctx context.Context,
 	instance *octaviav1.OctaviaAPI,
 	h *helper.Helper,
 	envVars *map[string]env.Setter,
 ) error {
 	Log := r.GetLogger(ctx)
-	Log.Info("Generating service config map")
+	Log.Info("Generating service secrets")
 	//
-	// create Configmap/Secret required for octavia input
-	// - %-scripts configmap holding scripts to e.g. bootstrap the service
-	// - %-config configmap holding minimal octavia config required to get the service up, user can add additional files to be added to the service
-	// - parameters which has passwords gets added from the ospSecret via the init container
+	// create Secret required for octavia input
+	// - %-scripts secret holding scripts to e.g. bootstrap the service
+	// - %-config secret holding minimal octavia config required to get the service up, user can add additional files to be added to the service
 	//
 
 	cmLabels := labels.GetLabels(instance, labels.GetGroupLabel(octavia.ServiceName), map[string]string{})
+
+	//
+	// check for required OpenStack secret holding passwords for service/admin user and add hash to the vars map
+	//
+	ospSecret, _, err := oko_secret.GetSecret(ctx, h, instance.Spec.Secret, instance.Namespace)
+	if err != nil {
+		if k8s_errors.IsNotFound(err) {
+			Log.Info(fmt.Sprintf("OpenStack secret %s not found", instance.Spec.Secret))
+			instance.Status.Conditions.Set(condition.FalseCondition(
+				condition.InputReadyCondition,
+				condition.RequestedReason,
+				condition.SeverityInfo,
+				condition.InputReadyWaitingMessage))
+			return err
+		}
+		instance.Status.Conditions.Set(condition.FalseCondition(
+			condition.InputReadyCondition,
+			condition.ErrorReason,
+			condition.SeverityWarning,
+			condition.InputReadyErrorMessage,
+			err.Error()))
+		return err
+	}
+	servicePassword := string(ospSecret.Data[instance.Spec.PasswordSelectors.Service])
+
+	transportURLSecret, _, err := oko_secret.GetSecret(ctx, h, instance.Spec.TransportURLSecret, instance.Namespace)
+	if err != nil {
+		if k8s_errors.IsNotFound(err) {
+			Log.Info(fmt.Sprintf("TransportURL secret %s not found", instance.Spec.TransportURLSecret))
+			instance.Status.Conditions.Set(condition.FalseCondition(
+				condition.InputReadyCondition,
+				condition.RequestedReason,
+				condition.SeverityInfo,
+				condition.InputReadyWaitingMessage))
+			return err
+		}
+		instance.Status.Conditions.Set(condition.FalseCondition(
+			condition.InputReadyCondition,
+			condition.ErrorReason,
+			condition.SeverityWarning,
+			condition.InputReadyErrorMessage,
+			err.Error()))
+		return err
+	}
+	transportURL := string(transportURLSecret.Data["transport_url"])
 
 	db, err := mariadbv1.GetDatabaseByNameAndAccount(ctx, h, octavia.DatabaseName, instance.Spec.DatabaseAccount, instance.Namespace)
 	if err != nil {
@@ -951,6 +945,9 @@ func (r *OctaviaAPIReconciler) generateServiceConfigMaps(
 		),
 	}
 
+	templateParameters["Password"] = servicePassword
+	templateParameters["TransportURL"] = transportURL
+
 	templateParameters["ServiceUser"] = instance.Spec.ServiceUser
 	templateParameters["KeystoneInternalURL"] = keystoneInternalURL
 	templateParameters["KeystonePublicURL"] = keystonePublicURL
@@ -981,7 +978,6 @@ func (r *OctaviaAPIReconciler) generateServiceConfigMaps(
 	templateParameters["VHosts"] = httpdVhostConfig
 
 	cms := []util.Template{
-		// ScriptsConfigMap
 		{
 			Name:               fmt.Sprintf("%s-scripts", instance.Name),
 			Namespace:          instance.Namespace,
@@ -990,7 +986,6 @@ func (r *OctaviaAPIReconciler) generateServiceConfigMaps(
 			AdditionalTemplate: map[string]string{"common.sh": "/common/common.sh"},
 			Labels:             cmLabels,
 		},
-		// ConfigMap
 		{
 			Name:          fmt.Sprintf("%s-config-data", instance.Name),
 			Namespace:     instance.Namespace,
@@ -1004,10 +999,10 @@ func (r *OctaviaAPIReconciler) generateServiceConfigMaps(
 	err = oko_secret.EnsureSecrets(ctx, h, instance, cms, envVars)
 
 	if err != nil {
-		Log.Error(err, "unable to process config map")
+		Log.Error(err, "unable to process secrets")
 		return err
 	}
-	Log.Info("Service config map generated")
+	Log.Info("Service secrets generated")
 
 	return nil
 }

--- a/controllers/octaviarsyslog_controller.go
+++ b/controllers/octaviarsyslog_controller.go
@@ -236,10 +236,10 @@ func (r *OctaviaRsyslogReconciler) reconcileNormal(ctx context.Context, instance
 		common.AppSelector: instance.ObjectMeta.Name,
 	}
 
-	// Handle config map
-	configMapVars := make(map[string]env.Setter)
+	// Handle secrets
+	secretsVars := make(map[string]env.Setter)
 
-	err = r.generateServiceConfigMaps(ctx, instance, helper, &configMapVars)
+	err = r.generateServiceSecrets(ctx, instance, helper, &secretsVars)
 	if err != nil {
 		instance.Status.Conditions.Set(condition.FalseCondition(
 			condition.ServiceConfigReadyCondition,
@@ -256,7 +256,7 @@ func (r *OctaviaRsyslogReconciler) reconcileNormal(ctx context.Context, instance
 	// create hash over all the different input resources to identify if any those changed
 	// and a restart/recreate is required.
 	//
-	inputHash, err := r.createHashOfInputHashes(instance, configMapVars)
+	inputHash, err := r.createHashOfInputHashes(instance, secretsVars)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
@@ -360,7 +360,7 @@ func (r *OctaviaRsyslogReconciler) reconcileNormal(ctx context.Context, instance
 	return ctrl.Result{}, nil
 }
 
-func (r *OctaviaRsyslogReconciler) generateServiceConfigMaps(
+func (r *OctaviaRsyslogReconciler) generateServiceSecrets(
 	ctx context.Context,
 	instance *octaviav1.OctaviaRsyslog,
 	helper *helper.Helper,

--- a/pkg/amphoracontrollers/daemonset.go
+++ b/pkg/amphoracontrollers/daemonset.go
@@ -162,13 +162,8 @@ func DaemonSet(
 	}
 
 	initContainerDetails := octavia.APIDetails{
-		ContainerImage:       instance.Spec.ContainerImage,
-		DatabaseHost:         instance.Spec.DatabaseHostname,
-		DatabaseName:         octavia.DatabaseName,
-		OSPSecret:            instance.Spec.Secret,
-		TransportURLSecret:   instance.Spec.TransportURLSecret,
-		UserPasswordSelector: instance.Spec.PasswordSelectors.Service,
-		VolumeMounts:         octavia.GetInitVolumeMounts(),
+		ContainerImage: instance.Spec.ContainerImage,
+		VolumeMounts:   octavia.GetInitVolumeMounts(),
 	}
 	daemonset.Spec.Template.Spec.InitContainers = octavia.InitContainer(initContainerDetails)
 

--- a/pkg/octavia/dbsync.go
+++ b/pkg/octavia/dbsync.go
@@ -87,13 +87,8 @@ func DbSyncJob(
 	}
 
 	initContainerDetails := APIDetails{
-		ContainerImage:          instance.Spec.OctaviaAPI.ContainerImage,
-		DatabaseHost:            instance.Status.DatabaseHostname,
-		DatabaseName:            DatabaseName,
-		PersistenceDatabaseName: PersistenceDatabaseName,
-		OSPSecret:               instance.Spec.Secret,
-		UserPasswordSelector:    instance.Spec.PasswordSelectors.Service,
-		VolumeMounts:            initVolumeMounts,
+		ContainerImage: instance.Spec.OctaviaAPI.ContainerImage,
+		VolumeMounts:   initVolumeMounts,
 	}
 	job.Spec.Template.Spec.InitContainers = InitContainer(initContainerDetails)
 

--- a/pkg/octaviaapi/deployment.go
+++ b/pkg/octaviaapi/deployment.go
@@ -197,13 +197,8 @@ func Deployment(
 	}
 
 	initContainerDetails := octavia.APIDetails{
-		ContainerImage:       instance.Spec.ContainerImage,
-		DatabaseHost:         instance.Spec.DatabaseHostname,
-		DatabaseName:         octavia.DatabaseName,
-		OSPSecret:            instance.Spec.Secret,
-		TransportURLSecret:   instance.Spec.TransportURLSecret,
-		UserPasswordSelector: instance.Spec.PasswordSelectors.Service,
-		VolumeMounts:         initVolumeMounts,
+		ContainerImage: instance.Spec.ContainerImage,
+		VolumeMounts:   initVolumeMounts,
 	}
 	deployment.Spec.Template.Spec.InitContainers = octavia.InitContainer(initContainerDetails)
 

--- a/templates/octavia/bin/init.sh
+++ b/templates/octavia/bin/init.sh
@@ -17,10 +17,6 @@ set -ex
 
 # This script generates the octavia.conf/logging.conf file and
 # copies the result to the ephemeral /var/lib/config-data/merged volume.
-#
-# Secrets are obtained from ENV variables.
-export PASSWORD=${AdminPassword:?"Please specify a AdminPassword variable."}
-export TRANSPORTURL=${TransportURL:-""}
 
 SVC_CFG=/etc/octavia/octavia.conf
 SVC_CFG_MERGED=/var/lib/config-data/merged/octavia.conf
@@ -36,9 +32,3 @@ cp -a ${SVC_CFG} ${SVC_CFG_MERGED}
 for dir in /var/lib/config-data/default; do
     merge_config_dir ${dir}
 done
-
-# set secrets
-if [ -n "$TRANSPORTURL" ]; then
-    crudini --set /var/lib/config-data/merged/octavia.conf DEFAULT transport_url $TRANSPORTURL
-fi
-crudini --set ${SVC_CFG_MERGED} keystone_authtoken password $PASSWORD

--- a/templates/octavia/config/octavia.conf
+++ b/templates/octavia/config/octavia.conf
@@ -15,7 +15,6 @@ connection = {{ .DatabaseConnection }}
 [health_manager]
 health_update_threads=4
 stats_update_threads=4
-# heartbeat_key=FIXMEkey1
 [keystone_authtoken]
 username={{ .ServiceUser }}
 # password=FIXMEpw3

--- a/templates/octaviaamphoracontroller/bin/init.sh
+++ b/templates/octaviaamphoracontroller/bin/init.sh
@@ -17,10 +17,6 @@ set -ex
 
 # This script generates the octavia.conf/logging.conf file and
 # copies the result to the ephemeral /var/lib/config-data/merged volume.
-#
-# Secrets are obtained from ENV variables.
-export PASSWORD=${AdminPassword:?"Please specify a AdminPassword variable."}
-export TRANSPORTURL=${TransportURL:-""}
 
 SVC_CFG=/etc/octavia/octavia.conf
 SVC_CFG_MERGED=/var/lib/config-data/merged/octavia.conf
@@ -36,11 +32,3 @@ cp -a ${SVC_CFG} ${SVC_CFG_MERGED}
 for dir in /var/lib/config-data/default; do
     merge_config_dir ${dir}
 done
-
-# set secrets
-if [ -n "$TRANSPORTURL" ]; then
-    crudini --set /var/lib/config-data/merged/octavia.conf DEFAULT transport_url $TRANSPORTURL
-fi
-# set secrets
-crudini --set ${SVC_CFG_MERGED} keystone_authtoken password $PASSWORD
-crudini --set ${SVC_CFG_MERGED} service_auth password $PASSWORD

--- a/templates/octaviaamphoracontroller/config/octavia.conf
+++ b/templates/octaviaamphoracontroller/config/octavia.conf
@@ -1,5 +1,6 @@
 [DEFAULT]
 debug=True
+transport_url={{ .TransportURL }}
 rpc_response_timeout=60
 # Long timeout until jobboard is used
 # TODO(gthiemonge) This setting must be updated/removed when Jobboard is
@@ -14,12 +15,11 @@ health_update_threads=4
 stats_update_threads=4
 bind_ip=::
 controller_ip_port_list={{ .ControllerIPList }}
-# heartbeat_key=FIXMEkey1
 [keystone_authtoken]
 www_authenticate_uri={{ .KeystonePublicURL }}
 auth_url={{ .KeystoneInternalURL }}
 username={{ .ServiceUser }}
-# password=FIXMEpw3
+password={{ .Password }}
 project_name=service
 project_domain_name=Default
 user_domain_name=Default
@@ -69,7 +69,7 @@ disable_local_log_storage=False
 project_domain_name=Default
 project_name=service
 user_domain_name=Default
-password=FIXMEpw3
+password={{ .Password }}
 username=octavia
 auth_type=password
 auth_url={{ .KeystoneInternalURL }}/v3

--- a/templates/octaviaapi/bin/init.sh
+++ b/templates/octaviaapi/bin/init.sh
@@ -17,10 +17,6 @@ set -ex
 
 # This script generates the octavia.conf/logging.conf file and
 # copies the result to the ephemeral /var/lib/config-data/merged volume.
-#
-# Secrets are obtained from ENV variables.
-export PASSWORD=${AdminPassword:?"Please specify a AdminPassword variable."}
-export TRANSPORTURL=${TransportURL:-""}
 
 SVC_CFG=/etc/octavia/octavia.conf
 SVC_CFG_MERGED=/var/lib/config-data/merged/octavia.conf
@@ -36,11 +32,3 @@ cp -a ${SVC_CFG} ${SVC_CFG_MERGED}
 for dir in /var/lib/config-data/default; do
     merge_config_dir ${dir}
 done
-
-# set secrets
-if [ -n "$TRANSPORTURL" ]; then
-    crudini --set /var/lib/config-data/merged/octavia.conf DEFAULT transport_url $TRANSPORTURL
-fi
-# set secrets
-crudini --set ${SVC_CFG_MERGED} keystone_authtoken password $PASSWORD
-crudini --set ${SVC_CFG_MERGED} service_auth password $PASSWORD

--- a/templates/octaviaapi/config/octavia.conf
+++ b/templates/octaviaapi/config/octavia.conf
@@ -1,5 +1,6 @@
 [DEFAULT]
 debug=True
+transport_url={{ .TransportURL }}
 rpc_response_timeout=60
 [api_settings]
 bind_host=192.168.1.147
@@ -15,12 +16,11 @@ connection = {{ .DatabaseConnection }}
 [health_manager]
 health_update_threads=4
 stats_update_threads=4
-# heartbeat_key=FIXMEkey1
 [keystone_authtoken]
 www_authenticate_uri={{ .KeystonePublicURL }}
 auth_url={{ .KeystoneInternalURL }}
 username={{ .ServiceUser }}
-# password=FIXMEpw3
+password={{ .Password }}
 project_name=service
 project_domain_name=Default
 user_domain_name=Default
@@ -76,7 +76,7 @@ disable_local_log_storage=False
 project_domain_name=Default
 project_name=service
 user_domain_name=Default
-password=FIXMEpw3
+password={{ .Password }}
 username=octavia
 auth_type=password
 auth_url={{ .KeystoneInternalURL }}/v3

--- a/tests/kuttl/common/assert_sample_deployment.yaml
+++ b/tests/kuttl/common/assert_sample_deployment.yaml
@@ -152,21 +152,6 @@ spec:
         - /usr/local/bin/container-scripts/init.sh
         command:
         - /bin/bash
-        env:
-        - name: AdminPassword
-          valueFrom:
-            secretKeyRef:
-              key: OctaviaPassword
-              name: osp-secret
-        - name: TransportURL
-          valueFrom:
-            secretKeyRef:
-              key: transport_url
-              name: rabbitmq-transport-url-octavia-octavia-transport
-        - name: DatabaseHost
-          value: openstack.octavia-kuttl-tests.svc
-        - name: DatabaseName
-          value: octavia
         imagePullPolicy: IfNotPresent
         name: init
         resources: {}

--- a/tests/kuttl/tests/octavia_tls/02-assert.yaml
+++ b/tests/kuttl/tests/octavia_tls/02-assert.yaml
@@ -220,21 +220,6 @@ spec:
         - /usr/local/bin/container-scripts/init.sh
         command:
         - /bin/bash
-        env:
-        - name: AdminPassword
-          valueFrom:
-            secretKeyRef:
-              key: OctaviaPassword
-              name: osp-secret
-        - name: TransportURL
-          valueFrom:
-            secretKeyRef:
-              key: transport_url
-              name: rabbitmq-transport-url-octavia-octavia-transport
-        - name: DatabaseHost
-          value: openstack.octavia-kuttl-tests.svc
-        - name: DatabaseName
-          value: octavia
         imagePullPolicy: IfNotPresent
         name: init
         resources: {}


### PR DESCRIPTION
Pass TransportURL and ServicePassword directly in the config file instead of using container environment variables.
Clean up unused environmnet variables (DatabaseHost, DatabaseName) Rename incorrect variable and function names that referred to ConfigMaps instead of Secrets

[OSPRH-9908](https://issues.redhat.com//browse/OSPRH-9908)