### PR TITLE
Add default timeout for Octavia API route annotations

### DIFF
--- a/api/bases/octavia.openstack.org_octavias.yaml
+++ b/api/bases/octavia.openstack.org_octavias.yaml
@@ -74,6 +74,9 @@ spec:
               apacheContainerImage:
                 description: Apache Container Image URL
                 type: string
+              apiTimeout:
+                description: Octavia API timeout
+                type: string
               customServiceConfig:
                 default: '# add your customization here'
                 description: CustomServiceConfig - customize the service config using

--- a/api/v1beta1/octavia_types.go
+++ b/api/v1beta1/octavia_types.go
@@ -40,6 +40,9 @@ const (
 
 	// ApacheImage - default fall-back image for Apache
 	ApacheContainerImage = "registry.redhat.io/ubi9/httpd-24:latest"
+
+	// Octavia API timeout
+	APITimeout = "120"
 )
 
 // OctaviaSpec defines the desired state of Octavia
@@ -201,6 +204,10 @@ type OctaviaSpecBase struct {
 	// Apache Container Image URL
 	ApacheContainerImage string `json:"apacheContainerImage"`
 
+	// +kubebuilder:validation:Optional
+	// Octavia API timeout
+	APITimeout string `json:"apiTimeout,omitempty"`
+
 	// +kubebuilder:validation:Required
 	// +kubebuilder:default=octavia
 	// OctaviaNetworkAttachment is a NetworkAttachment resource name for the Octavia Management Network
@@ -343,6 +350,7 @@ func SetupDefaults() {
 		HealthManagerContainerImageURL: util.GetEnvVar("RELATED_IMAGE_OCTAVIA_HEALTHMANAGER_IMAGE_URL_DEFAULT", OctaviaHealthManagerContainerImage),
 		WorkerContainerImageURL:        util.GetEnvVar("RELATED_IMAGE_OCTAVIA_WORKER_IMAGE_URL_DEFAULT", OctaviaWorkerContainerImage),
 		ApacheContainerImageURL:        util.GetEnvVar("RELATED_IMAGE_OCTAVIA_APACHE_IMAGE_URL_DEFAULT", ApacheContainerImage),
+		OctaviaAPIRouteTimeout:         util.GetEnvVar("OCTAVIA_API_TIMEOUT", APITimeout),
 		// No default for AmphoraImageContainerImageURL
 	}
 

--- a/api/v1beta1/octavia_webhook.go
+++ b/api/v1beta1/octavia_webhook.go
@@ -37,6 +37,7 @@ type OctaviaDefaults struct {
 	HealthManagerContainerImageURL string
 	WorkerContainerImageURL        string
 	ApacheContainerImageURL        string
+	OctaviaAPIRouteTimeout         string
 }
 
 var octaviaDefaults OctaviaDefaults
@@ -195,4 +196,11 @@ func (r *Octavia) ValidateDelete() (admission.Warnings, error) {
 
 	// TODO(user): fill in your validation logic upon object deletion.
 	return nil, nil
+}
+
+func (spec *OctaviaSpec) GetDefaultRouteAnnotations() (annotations map[string]string) {
+	annotations = map[string]string{
+		"haproxy.router.openshift.io/timeout": octaviaDefaults.OctaviaAPIRouteTimeout,
+	}
+	return
 }

--- a/config/crd/bases/octavia.openstack.org_octavias.yaml
+++ b/config/crd/bases/octavia.openstack.org_octavias.yaml
@@ -74,6 +74,9 @@ spec:
               apacheContainerImage:
                 description: Apache Container Image URL
                 type: string
+              apiTimeout:
+                description: Octavia API timeout
+                type: string
               customServiceConfig:
                 default: '# add your customization here'
                 description: CustomServiceConfig - customize the service config using

--- a/config/default/manager_default_images.yaml
+++ b/config/default/manager_default_images.yaml
@@ -21,3 +21,5 @@ spec:
           value: quay.io/podified-antelope-centos9/openstack-octavia-worker:current-podified
         - name: RELATED_IMAGE_OCTAVIA_APACHE_IMAGE_URL_DEFAULT
           value: registry.redhat.io/ubi9/httpd-24:latest
+        - name: OCTAVIA_API_TIMEOUT
+          value: "120"


### PR DESCRIPTION
Add the timeout property as required annotation for the Octavia API Route. This needs to be followed by a commit in openstack-operator since the route is defined there, where we will call to GetDefaultRouteAnnotations method added here.