### PR TITLE
Fixed backtraces when setting up watchers

### DIFF
--- a/controllers/amphoracontroller_controller.go
+++ b/controllers/amphoracontroller_controller.go
@@ -729,6 +729,11 @@ func (r *OctaviaAmphoraControllerReconciler) findObjectsForSrc(ctx context.Conte
 
 	l := log.FromContext(ctx).WithName("Controllers").WithName("Amphora")
 
+	allWatchFields := []string{
+		passwordSecretField,
+		caBundleSecretNameField,
+	}
+
 	for _, field := range allWatchFields {
 		crList := &octaviav1.OctaviaAmphoraControllerList{}
 		listOps := &client.ListOptions{


### PR DESCRIPTION
[0] added log messages when a field doesn't exist in the spec. It uncovered some errors in the amphora controller. Remove the non-existing fields from the watcher

[0] https://github.com/openstack-k8s-operators/octavia-operator/pull/389

JIRA: [OSPRH-10725](https://issues.redhat.com//browse/OSPRH-10725)