### PR TITLE
set securityContext.runAsNonRoot value to true

### DIFF
--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -12,6 +12,7 @@ spec:
       - name: kube-rbac-proxy
         securityContext:
           allowPrivilegeEscalation: false
+          runAsNonRoot: true
           capabilities:
             drop:
               - "ALL"


### PR DESCRIPTION
Reported by SAST tool:
Sigma main event: The Kubernetes container is allowed to run as the root user. This may allow attackers to gain the root privileges of the host when the container is compromised.
remediation: Explicitly set the 'securityContext.runAsNonRoot' value to 'true' to prevent the container from running as a root-level user.

JIRA: [OSPRH-9907](https://issues.redhat.com//browse/OSPRH-9907)