### PR TITLE
Move GetDefaultRouteAnnotations to SpecCore

### DIFF
--- a/api/v1beta1/octavia_webhook.go
+++ b/api/v1beta1/octavia_webhook.go
@@ -198,7 +198,7 @@ func (r *Octavia) ValidateDelete() (admission.Warnings, error) {
 	return nil, nil
 }
 
-func (spec *OctaviaSpec) GetDefaultRouteAnnotations() (annotations map[string]string) {
+func (spec *OctaviaSpecCore) GetDefaultRouteAnnotations() (annotations map[string]string) {
 	annotations = map[string]string{
 		"haproxy.router.openshift.io/timeout": octaviaDefaults.OctaviaAPIRouteTimeout,
 	}


### PR DESCRIPTION
The GetDefaultRouteAnnotations function needs to be a method of the OctaviaSpecCore struct rather than OctaviaSpec. This will resolve the issue seen in: https://github.com/openstack-k8s-operators/openstack-operator/pull/1071