### PR TITLE
Fix default values for nested structs

### DIFF
--- a/api/bases/octavia.openstack.org_octavias.yaml
+++ b/api/bases/octavia.openstack.org_octavias.yaml
@@ -124,6 +124,7 @@ spec:
                       type: string
                     type: array
                   createDefaultLbMgmtNetwork:
+                    default: true
                     description: CreateDefaultLbMgmtNetwork - when True, octavia-operator
                       creates a Management Network for the default Availability Zone
                       of the control plane. Can be set to false when deploying OpenStack
@@ -136,6 +137,7 @@ spec:
                       Attachment Definition
                     type: string
                   manageLbMgmtNetworks:
+                    default: true
                     description: ManageLbMgmtNetworks - when True, octavia-operator
                       creates the Neutron resources needed for its Management Network
                     type: boolean

--- a/api/v1beta1/octavia_types.go
+++ b/api/v1beta1/octavia_types.go
@@ -230,10 +230,12 @@ type PasswordSelector struct {
 // OctaviaLbMgmtNetworks Settings for Octavia management networks
 type OctaviaLbMgmtNetworks struct {
 	// +kubebuilder:validation:Optional
+	// +kubebuilder:default=true
 	// ManageLbMgmtNetworks - when True, octavia-operator creates the Neutron resources needed for its Management Network
 	ManageLbMgmtNetworks bool `json:"manageLbMgmtNetworks"`
 
 	// +kubebuilder:validation:Optional
+	// +kubebuilder:default=true
 	// CreateDefaultLbMgmtNetwork - when True, octavia-operator creates a
 	// Management Network for the default Availability Zone of the control
 	// plane. Can be set to false when deploying OpenStack in DCN mode.

--- a/config/crd/bases/octavia.openstack.org_octavias.yaml
+++ b/config/crd/bases/octavia.openstack.org_octavias.yaml
@@ -124,6 +124,7 @@ spec:
                       type: string
                     type: array
                   createDefaultLbMgmtNetwork:
+                    default: true
                     description: CreateDefaultLbMgmtNetwork - when True, octavia-operator
                       creates a Management Network for the default Availability Zone
                       of the control plane. Can be set to false when deploying OpenStack
@@ -136,6 +137,7 @@ spec:
                       Attachment Definition
                     type: string
                   manageLbMgmtNetworks:
+                    default: true
                     description: ManageLbMgmtNetworks - when True, octavia-operator
                       creates the Neutron resources needed for its Management Network
                     type: boolean

--- a/config/samples/octavia_v1beta1_octavia.yaml
+++ b/config/samples/octavia_v1beta1_octavia.yaml
@@ -10,6 +10,9 @@ spec:
   rabbitMqClusterName: rabbitmq
   secret: osp-secret
   preserveJobs: false
+  lbMgmtNetwork:
+    availabilityZones:
+    - zone-1
   customServiceConfig: |
     [DEFAULT]
     debug = true

--- a/tests/kuttl/common/assert_sample_deployment.yaml
+++ b/tests/kuttl/common/assert_sample_deployment.yaml
@@ -23,6 +23,11 @@ spec:
   preserveJobs: false
   secret: osp-secret
   serviceUser: octavia
+  lbMgmtNetwork:
+    availabilityZones:
+    - zone-1
+    manageLbMgmtNetworks: true
+    createDefaultLbMgmtNetwork: true
   octaviaAPI:
     customServiceConfig: |
       [DEFAULT]

--- a/tests/kuttl/tests/octavia_scale/00-test-resources.yaml
+++ b/tests/kuttl/tests/octavia_scale/00-test-resources.yaml
@@ -3,3 +3,10 @@ kind: TestStep
 commands:
   - script: |
       oc kustomize ../../../../config/samples/network-attachment-definition | oc apply -n $NAMESPACE -f -
+  - script: |
+      oc patch -n $NAMESPACE ovncontrollers ovncontroller-sample --type merge -p '
+      spec:
+        external-ids:
+          availability-zones:
+          - zone-1
+      '


### PR DESCRIPTION
Setting the default values following the guidelines [0]

It fixes an issue that happens when setting a field in the struct, it also resets the other settings regardless of their default values.

[0] https://github.com/openstack-k8s-operators/dev-docs/blob/417ed0a8ce8ee48de370aa3c6a964fcbdf802d3d/developer.md#defaulting-structs

JIRA: [OSPRH-11092](https://issues.redhat.com//browse/OSPRH-11092)