### PR TITLE
Change apiTimeout type to Optional

### DIFF
--- a/api/bases/octavia.openstack.org_octavias.yaml
+++ b/api/bases/octavia.openstack.org_octavias.yaml
@@ -1388,7 +1388,6 @@ spec:
                 type: string
             required:
             - apacheContainerImage
-            - apiTimeout
             - databaseInstance
             - octaviaAPI
             - octaviaNetworkAttachment

--- a/api/v1beta1/octavia_types.go
+++ b/api/v1beta1/octavia_types.go
@@ -204,7 +204,7 @@ type OctaviaSpecBase struct {
 	// Apache Container Image URL
 	ApacheContainerImage string `json:"apacheContainerImage"`
 
-	// +kubebuilder:validation:Required
+	// +kubebuilder:validation:Optional
 	// +kubebuilder:default=120
 	// Octavia API timeout
 	APITimeout int `json:"apiTimeout"`

--- a/config/crd/bases/octavia.openstack.org_octavias.yaml
+++ b/config/crd/bases/octavia.openstack.org_octavias.yaml
@@ -1388,7 +1388,6 @@ spec:
                 type: string
             required:
             - apacheContainerImage
-            - apiTimeout
             - databaseInstance
             - octaviaAPI
             - octaviaNetworkAttachment


### PR DESCRIPTION
To keep backward compatibility with updates/upgrades of existing env, this parameter can not be type Required.

Error msg on update env:

```
message: 'error validating existing CRs against new CRD''s schema for "openstackcontrolplanes.core.openstack.org":                       error validating core.openstack.org/v1beta1, Kind=OpenStackControlPlane "openstack/controlplane":
    updated validation is too restrictive: [].spec.octavia.template.apiTimeout: Required
    value'
```