### PR TITLE
Use nodeSelector for predictable IP address allocation

### DIFF
--- a/MANAGEMENT_NETWORK.md
+++ b/MANAGEMENT_NETWORK.md
@@ -316,3 +316,24 @@ The `fixed_ips`, `device_id` and `device_owner` are all of interest:
 * `fixed_ips` will match the IP for the `interfaces_info` of the `octavia-link-router`
 * `device_id` will match the ID for the `octavia-link-router`
 * `device_owner` indicates that OpenStack is using the port as a router interface
+
+## Running the Octavia Amphora Controller Pods on specific Nodes
+
+By default, the Amphora Controller pods are deployed on all the nodes of a
+cluster. In case of a cluster with a high number of nodes, it's not needed,
+it's preferable to use only 3 nodes.
+An admin can limit the number of instances of these services by using
+a `nodeSelector`. They add a label on specific nodes to indicate that they will
+host the Octavia services.
+
+For instance, set a label on master-2:
+
+```shell
+$ oc patch nodes master-2 --type merge --patch '{"metadata":{"labels":{"openstack.org/octavia-controller":""}}}'
+```
+
+Make the Octavia services run only on these nodes:
+
+```shell
+$ oc patch -n openstack openstackcontrolplane controlplane --type merge --patch '{"spec":{"octavia":{"template":{"nodeSelector":{"openstack.org/octavia-controller":""}}}}}'
+```

--- a/controllers/octavia_controller.go
+++ b/controllers/octavia_controller.go
@@ -53,6 +53,7 @@ import (
 	rbacv1 "k8s.io/api/rbac/v1"
 
 	k8s_errors "k8s.io/apimachinery/pkg/api/errors"
+	k8s_labels "k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -787,7 +788,11 @@ func (r *OctaviaReconciler) reconcileNormal(ctx context.Context, instance *octav
 	// * do we want to provide a mechanism to temporarily disabling this list
 	// for maintenance windows where nodes might be "coming and going"
 
-	nodes, err := helper.GetKClient().CoreV1().Nodes().List(ctx, metav1.ListOptions{})
+	listOpts := metav1.ListOptions{}
+	if instance.Spec.NodeSelector != nil {
+		listOpts.LabelSelector = k8s_labels.Set(*instance.Spec.NodeSelector).String()
+	}
+	nodes, err := helper.GetKClient().CoreV1().Nodes().List(ctx, listOpts)
 	if err != nil {
 		return ctrl.Result{}, err
 	}


### PR DESCRIPTION
Allocate IP addresses only for nodes that run the octavia services.

JIRA: [OSPRH-11747](https://issues.redhat.com//browse/OSPRH-11747)