### PR TITLE
Don't block CIDR masks other than 16/64

### DIFF
--- a/pkg/octavia/network_parameters.go
+++ b/pkg/octavia/network_parameters.go
@@ -135,18 +135,6 @@ func GetNetworkParametersFromNAD(
 	if len(nadConfig.IPAM.Routes) > 0 {
 		networkParameters.TenantCIDR = nadConfig.IPAM.Routes[0].Destination
 
-		// For IPv4, we require a /16 subnet, for IPv6 a /64
-		var bitlen int
-		if networkParameters.TenantCIDR.Addr().Is6() {
-			bitlen = 64
-		} else {
-			bitlen = 16
-		}
-
-		if networkParameters.TenantCIDR.Bits() != bitlen {
-			return nil, fmt.Errorf("the tenant CIDR is /%d, it should be /%d", networkParameters.TenantCIDR.Bits(), bitlen)
-		}
-
 		// Compute an allocation range based on the CIDR
 		start, end := GetRangeFromCIDR(networkParameters.TenantCIDR)
 		networkParameters.TenantAllocationStart = start


### PR DESCRIPTION
PR 422 allowed computing subnet ranges from CIDRs with any masks, but the code still checks that the NAD ipam.routes[0].dst is a /16 (ipv4) or /64 (ipv6), we can now remove this restriction.

JIRA: [OSPRH-11711](https://issues.redhat.com//browse/OSPRH-11711)