### PR TITLE
Add missing condition in amphora controller when octavia-api is not ready

### DIFF
--- a/controllers/amphoracontroller_controller.go
+++ b/controllers/amphoracontroller_controller.go
@@ -271,6 +271,12 @@ func (r *OctaviaAmphoraControllerReconciler) reconcileNormal(ctx context.Context
 
 	defaultFlavorID, err := amphoracontrollers.EnsureFlavors(ctx, instance, &r.Log, helper)
 	if err != nil {
+		instance.Status.Conditions.Set(condition.FalseCondition(
+			condition.InputReadyCondition,
+			condition.ErrorReason,
+			condition.SeverityWarning,
+			condition.InputReadyErrorMessage,
+			err.Error()))
 		return ctrl.Result{RequeueAfter: time.Duration(60) * time.Second}, nil
 	}
 	r.Log.Info(fmt.Sprintf("Using default flavor \"%s\"", defaultFlavorID))


### PR DESCRIPTION
When the octavia-api service is not ready or not available, the flavor creation fails, it triggers a RequeueAfter 60 sec without any explanations (condition or logs)
Add a condition error to indicate the cause of the wait/failure.