### PR TITLE
Fix setting project_name in config files

### DIFF
--- a/api/bases/octavia.openstack.org_octaviaamphoracontrollers.yaml
+++ b/api/bases/octavia.openstack.org_octaviaamphoracontrollers.yaml
@@ -230,7 +230,7 @@ spec:
               tenantName:
                 default: service
                 description: TenantName - the name of the OpenStack tenant that controls
-                  the Octavia resources TODO(gthiemonge) same as ServiceAccount?
+                  the Octavia resources
                 type: string
               tls:
                 description: TLS - Parameters related to the TLS

--- a/api/bases/octavia.openstack.org_octaviaapis.yaml
+++ b/api/bases/octavia.openstack.org_octaviaapis.yaml
@@ -366,6 +366,11 @@ spec:
                 default: octavia
                 description: ServiceUser - service user name
                 type: string
+              tenantName:
+                default: service
+                description: TenantName - the name of the OpenStack tenant that controls
+                  the Octavia resources
+                type: string
               tls:
                 description: TLS - Parameters related to the TLS
                 properties:

--- a/api/bases/octavia.openstack.org_octavias.yaml
+++ b/api/bases/octavia.openstack.org_octavias.yaml
@@ -480,6 +480,11 @@ spec:
                     default: octavia
                     description: ServiceUser - service user name
                     type: string
+                  tenantName:
+                    default: service
+                    description: TenantName - the name of the OpenStack tenant that
+                      controls the Octavia resources
+                    type: string
                   tls:
                     description: TLS - Parameters related to the TLS
                     properties:
@@ -715,7 +720,7 @@ spec:
                   tenantName:
                     default: service
                     description: TenantName - the name of the OpenStack tenant that
-                      controls the Octavia resources TODO(gthiemonge) same as ServiceAccount?
+                      controls the Octavia resources
                     type: string
                   tls:
                     description: TLS - Parameters related to the TLS
@@ -921,7 +926,7 @@ spec:
                   tenantName:
                     default: service
                     description: TenantName - the name of the OpenStack tenant that
-                      controls the Octavia resources TODO(gthiemonge) same as ServiceAccount?
+                      controls the Octavia resources
                     type: string
                   tls:
                     description: TLS - Parameters related to the TLS
@@ -1261,7 +1266,7 @@ spec:
                   tenantName:
                     default: service
                     description: TenantName - the name of the OpenStack tenant that
-                      controls the Octavia resources TODO(gthiemonge) same as ServiceAccount?
+                      controls the Octavia resources
                     type: string
                   tls:
                     description: TLS - Parameters related to the TLS

--- a/api/v1beta1/amphoracontroller_types.go
+++ b/api/v1beta1/amphoracontroller_types.go
@@ -120,7 +120,6 @@ type OctaviaAmphoraControllerSpecCore struct {
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:default=service
 	// TenantName - the name of the OpenStack tenant that controls the Octavia resources
-	// TODO(gthiemonge) same as ServiceAccount?
 	TenantName string `json:"tenantName"`
 
 	// +kubebuilder:validation:Optional

--- a/api/v1beta1/octaviaapi_types.go
+++ b/api/v1beta1/octaviaapi_types.go
@@ -138,6 +138,11 @@ type OctaviaAPISpecCore struct {
 	NetworkAttachments []string `json:"networkAttachments,omitempty"`
 
 	// +kubebuilder:validation:Optional
+	// +kubebuilder:default=service
+	// TenantName - the name of the OpenStack tenant that controls the Octavia resources
+	TenantName string `json:"tenantName"`
+
+	// +kubebuilder:validation:Optional
 	// +operator-sdk:csv:customresourcedefinitions:type=spec
 	// TLS - Parameters related to the TLS
 	TLS OctaviaApiTLS `json:"tls,omitempty"`

--- a/config/crd/bases/octavia.openstack.org_octaviaamphoracontrollers.yaml
+++ b/config/crd/bases/octavia.openstack.org_octaviaamphoracontrollers.yaml
@@ -230,7 +230,7 @@ spec:
               tenantName:
                 default: service
                 description: TenantName - the name of the OpenStack tenant that controls
-                  the Octavia resources TODO(gthiemonge) same as ServiceAccount?
+                  the Octavia resources
                 type: string
               tls:
                 description: TLS - Parameters related to the TLS

--- a/config/crd/bases/octavia.openstack.org_octaviaapis.yaml
+++ b/config/crd/bases/octavia.openstack.org_octaviaapis.yaml
@@ -366,6 +366,11 @@ spec:
                 default: octavia
                 description: ServiceUser - service user name
                 type: string
+              tenantName:
+                default: service
+                description: TenantName - the name of the OpenStack tenant that controls
+                  the Octavia resources
+                type: string
               tls:
                 description: TLS - Parameters related to the TLS
                 properties:

--- a/config/crd/bases/octavia.openstack.org_octavias.yaml
+++ b/config/crd/bases/octavia.openstack.org_octavias.yaml
@@ -480,6 +480,11 @@ spec:
                     default: octavia
                     description: ServiceUser - service user name
                     type: string
+                  tenantName:
+                    default: service
+                    description: TenantName - the name of the OpenStack tenant that
+                      controls the Octavia resources
+                    type: string
                   tls:
                     description: TLS - Parameters related to the TLS
                     properties:
@@ -715,7 +720,7 @@ spec:
                   tenantName:
                     default: service
                     description: TenantName - the name of the OpenStack tenant that
-                      controls the Octavia resources TODO(gthiemonge) same as ServiceAccount?
+                      controls the Octavia resources
                     type: string
                   tls:
                     description: TLS - Parameters related to the TLS
@@ -921,7 +926,7 @@ spec:
                   tenantName:
                     default: service
                     description: TenantName - the name of the OpenStack tenant that
-                      controls the Octavia resources TODO(gthiemonge) same as ServiceAccount?
+                      controls the Octavia resources
                     type: string
                   tls:
                     description: TLS - Parameters related to the TLS
@@ -1261,7 +1266,7 @@ spec:
                   tenantName:
                     default: service
                     description: TenantName - the name of the OpenStack tenant that
-                      controls the Octavia resources TODO(gthiemonge) same as ServiceAccount?
+                      controls the Octavia resources
                     type: string
                   tls:
                     description: TLS - Parameters related to the TLS

--- a/controllers/amphoracontroller_controller.go
+++ b/controllers/amphoracontroller_controller.go
@@ -618,6 +618,7 @@ func (r *OctaviaAmphoraControllerReconciler) generateServiceSecrets(
 	spec := instance.Spec
 	templateParameters["TransportURL"] = transportURL
 	templateParameters["ServiceUser"] = spec.ServiceUser
+	templateParameters["TenantName"] = spec.TenantName
 	templateParameters["Password"] = servicePassword
 	templateParameters["KeystoneInternalURL"] = keystoneInternalURL
 	templateParameters["KeystonePublicURL"] = keystonePublicURL

--- a/controllers/octavia_controller.go
+++ b/controllers/octavia_controller.go
@@ -1410,6 +1410,7 @@ func (r *OctaviaReconciler) generateServiceSecrets(
 		),
 	}
 	templateParameters["ServiceUser"] = instance.Spec.ServiceUser
+	templateParameters["TenantName"] = instance.Spec.TenantName
 
 	cms := []util.Template{
 		{
@@ -1481,6 +1482,7 @@ func (r *OctaviaReconciler) apiDeploymentCreateOrUpdate(instance *octaviav1.Octa
 		deployment.Spec.DatabaseAccount = instance.Spec.DatabaseAccount
 		deployment.Spec.PersistenceDatabaseAccount = instance.Spec.PersistenceDatabaseAccount
 		deployment.Spec.ServiceUser = instance.Spec.ServiceUser
+		deployment.Spec.TenantName = instance.Spec.TenantName
 		deployment.Spec.TransportURLSecret = instance.Status.TransportURLSecret
 		deployment.Spec.Secret = instance.Spec.Secret
 		deployment.Spec.ServiceAccount = instance.RbacResourceName()
@@ -1544,6 +1546,7 @@ func (r *OctaviaReconciler) amphoraControllerDaemonSetCreateOrUpdate(
 		daemonset.Spec.DatabaseAccount = instance.Spec.DatabaseAccount
 		daemonset.Spec.PersistenceDatabaseAccount = instance.Spec.PersistenceDatabaseAccount
 		daemonset.Spec.ServiceUser = instance.Spec.ServiceUser
+		daemonset.Spec.TenantName = instance.Spec.TenantName
 		daemonset.Spec.Secret = instance.Spec.Secret
 		daemonset.Spec.TransportURLSecret = instance.Status.TransportURLSecret
 		daemonset.Spec.ServiceAccount = instance.RbacResourceName()

--- a/controllers/octaviaapi_controller.go
+++ b/controllers/octaviaapi_controller.go
@@ -965,6 +965,7 @@ func (r *OctaviaAPIReconciler) generateServiceSecrets(
 	templateParameters["TransportURL"] = transportURL
 
 	templateParameters["ServiceUser"] = instance.Spec.ServiceUser
+	templateParameters["TenantName"] = instance.Spec.TenantName
 	templateParameters["KeystoneInternalURL"] = keystoneInternalURL
 	templateParameters["KeystonePublicURL"] = keystonePublicURL
 	templateParameters["NBConnection"], err = nbCluster.GetInternalEndpoint()

--- a/templates/octavia/config/octavia.conf
+++ b/templates/octavia/config/octavia.conf
@@ -18,7 +18,7 @@ stats_update_threads=4
 [keystone_authtoken]
 username={{ .ServiceUser }}
 # password=FIXMEpw3
-project_name=service
+project_name={{ .TenantName }}
 project_domain_name=Default
 user_domain_name=Default
 auth_type=password

--- a/templates/octaviaamphoracontroller/config/octavia.conf
+++ b/templates/octaviaamphoracontroller/config/octavia.conf
@@ -20,7 +20,7 @@ www_authenticate_uri={{ .KeystonePublicURL }}
 auth_url={{ .KeystoneInternalURL }}
 username={{ .ServiceUser }}
 password={{ .Password }}
-project_name=service
+project_name={{ .TenantName }}
 project_domain_name=Default
 user_domain_name=Default
 auth_type=password
@@ -67,7 +67,7 @@ disable_local_log_storage=False
 
 [service_auth]
 project_domain_name=Default
-project_name=service
+project_name={{ .TenantName }}
 user_domain_name=Default
 password={{ .Password }}
 username=octavia

--- a/templates/octaviaapi/config/octavia.conf
+++ b/templates/octaviaapi/config/octavia.conf
@@ -21,7 +21,7 @@ www_authenticate_uri={{ .KeystonePublicURL }}
 auth_url={{ .KeystoneInternalURL }}
 username={{ .ServiceUser }}
 password={{ .Password }}
-project_name=service
+project_name={{ .TenantName }}
 project_domain_name=Default
 user_domain_name=Default
 auth_type=password
@@ -74,7 +74,7 @@ disable_local_log_storage=False
 
 [service_auth]
 project_domain_name=Default
-project_name=service
+project_name={{ .TenantName }}
 user_domain_name=Default
 password={{ .Password }}
 username=octavia


### PR DESCRIPTION
'project_name=service' was hardcoded in the octavia config file but the name of the project depends on the value of spec.tenantName

JIRA: [OSPRH-12242](https://issues.redhat.com//browse/OSPRH-12242)