### PR TITLE
Add rsyslog image defaults

### DIFF
--- a/api/v1beta1/octavia_types.go
+++ b/api/v1beta1/octavia_types.go
@@ -41,6 +41,9 @@ const (
 	// ApacheImage - default fall-back image for Apache
 	ApacheContainerImage = "registry.redhat.io/ubi9/httpd-24:latest"
 
+	// OctaviaRsyslogContainer image is the fall-back container image for OctaviaRsyslog
+	RsyslogContainerImage = "quay.io/podified-antelope-centos9/openstack-rsyslog:current-podified"
+
 	// Octavia API timeout
 	APITimeout = 120
 )
@@ -369,6 +372,7 @@ func SetupDefaults() {
 		HealthManagerContainerImageURL: util.GetEnvVar("RELATED_IMAGE_OCTAVIA_HEALTHMANAGER_IMAGE_URL_DEFAULT", OctaviaHealthManagerContainerImage),
 		WorkerContainerImageURL:        util.GetEnvVar("RELATED_IMAGE_OCTAVIA_WORKER_IMAGE_URL_DEFAULT", OctaviaWorkerContainerImage),
 		ApacheContainerImageURL:        util.GetEnvVar("RELATED_IMAGE_OCTAVIA_APACHE_IMAGE_URL_DEFAULT", ApacheContainerImage),
+		RsyslogContainerImageURL:       util.GetEnvVar("RELATED_IMAGE_OCTAVIA_RSYSLOG_IMAGE_URL_DEFAULT", RsyslogContainerImage),
 		OctaviaAPIRouteTimeout:         APITimeout,
 		// No default for AmphoraImageContainerImageURL
 	}

--- a/api/v1beta1/octavia_webhook.go
+++ b/api/v1beta1/octavia_webhook.go
@@ -38,6 +38,7 @@ type OctaviaDefaults struct {
 	WorkerContainerImageURL        string
 	ApacheContainerImageURL        string
 	OctaviaAPIRouteTimeout         int
+	RsyslogContainerImageURL       string
 }
 
 var octaviaDefaults OctaviaDefaults
@@ -85,6 +86,9 @@ func (spec *OctaviaSpec) Default() {
 	}
 	if spec.ApacheContainerImage == "" {
 		spec.ApacheContainerImage = octaviaDefaults.ApacheContainerImageURL
+	}
+	if spec.OctaviaRsyslog.ContainerImage == "" {
+		spec.OctaviaRsyslog.ContainerImage = octaviaDefaults.RsyslogContainerImageURL
 	}
 }
 

--- a/config/default/manager_default_images.yaml
+++ b/config/default/manager_default_images.yaml
@@ -21,3 +21,5 @@ spec:
           value: quay.io/podified-antelope-centos9/openstack-octavia-worker:current-podified
         - name: RELATED_IMAGE_OCTAVIA_APACHE_IMAGE_URL_DEFAULT
           value: registry.redhat.io/ubi9/httpd-24:latest
+        - name: RELATED_IMAGE_OCTAVIA_RSYSLOG_IMAGE_URL_DEFAULT
+          value: quay.io/podified-antelope-centos9/openstack-rsyslog:current-podified

--- a/tests/kuttl/common/assert_sample_deployment.yaml
+++ b/tests/kuttl/common/assert_sample_deployment.yaml
@@ -241,6 +241,9 @@ commands:
             APACHE)
               template='{{.spec.apacheContainerImage}}'
               ;;
+            RSYSLOG)
+              template='{{.spec.octaviaRsyslog.containerImage}}'
+              ;;
           esac
           SERVICE_IMAGE=$(oc get -n $NAMESPACE octavia octavia -o go-template="$template")
           if [ "$SERVICE_IMAGE" != "$IMG_FROM_ENV" ]; then


### PR DESCRIPTION
The RELATED_IMAGE_OCTAVIA_RSYSLOG_IMAGE_URL_DEFAULT and related default overrides were missing for the log offloading feature.

JIRA: [OSPRH-12496](https://issues.redhat.com//browse/OSPRH-12496)