### PR TITLE
Use containerImage from env

### DIFF
--- a/api/bases/octavia.openstack.org_octaviarsyslogs.yaml
+++ b/api/bases/octavia.openstack.org_octaviarsyslogs.yaml
@@ -73,7 +73,7 @@ spec:
                 type: array
               containerImage:
                 default: quay.io/podified-antelope-centos9/openstack-rsyslog:current-podified
-                description: ContainerImage - Amphora Controller Container Image URL
+                description: ContainerImage - Rsyslog Container Image URL
                 type: string
               defaultConfigOverwrite:
                 additionalProperties:
@@ -83,6 +83,11 @@ spec:
                   But can also be used to add additional files. Those get added to the service config dir in /etc/<service> .
                   TODO: -> implement
                 type: object
+              initContainerImage:
+                default: quay.io/podified-antelope-centos9/openstack-octavia-health-manager:current-podified
+                description: InitContainerImage - Rsyslog init Container Image URL
+                  for
+                type: string
               networkAttachments:
                 default:
                 - octavia

--- a/api/bases/octavia.openstack.org_octavias.yaml
+++ b/api/bases/octavia.openstack.org_octavias.yaml
@@ -985,8 +985,7 @@ spec:
                     type: array
                   containerImage:
                     default: quay.io/podified-antelope-centos9/openstack-rsyslog:current-podified
-                    description: ContainerImage - Amphora Controller Container Image
-                      URL
+                    description: ContainerImage - Rsyslog Container Image URL
                     type: string
                   defaultConfigOverwrite:
                     additionalProperties:
@@ -996,6 +995,11 @@ spec:
                       But can also be used to add additional files. Those get added to the service config dir in /etc/<service> .
                       TODO: -> implement
                     type: object
+                  initContainerImage:
+                    default: quay.io/podified-antelope-centos9/openstack-octavia-health-manager:current-podified
+                    description: InitContainerImage - Rsyslog init Container Image
+                      URL for
+                    type: string
                   networkAttachments:
                     default:
                     - octavia

--- a/api/v1beta1/octavia_webhook.go
+++ b/api/v1beta1/octavia_webhook.go
@@ -90,6 +90,12 @@ func (spec *OctaviaSpec) Default() {
 	if spec.OctaviaRsyslog.ContainerImage == "" {
 		spec.OctaviaRsyslog.ContainerImage = octaviaDefaults.RsyslogContainerImageURL
 	}
+	if spec.OctaviaRsyslog.InitContainerImage == "" {
+		// TODO(gthiemonge) Using Octavia HM Container image is a workaround to get a container with pyroute2
+		// Replace it by an init container image with pyroute2 when it's available
+		// OSPRH-8434
+		spec.OctaviaRsyslog.InitContainerImage = octaviaDefaults.HealthManagerContainerImageURL
+	}
 }
 
 // Default - set defaults for this Octavia core spec (this version is used by the OpenStackControlplane webhook)

--- a/api/v1beta1/octaviarsyslog_types.go
+++ b/api/v1beta1/octaviarsyslog_types.go
@@ -28,8 +28,13 @@ type OctaviaRsyslogSpec struct {
 
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:default="quay.io/podified-antelope-centos9/openstack-rsyslog:current-podified"
-	// ContainerImage - Amphora Controller Container Image URL
+	// ContainerImage - Rsyslog Container Image URL
 	ContainerImage string `json:"containerImage,omitempty"`
+
+	// +kubebuilder:validation:Optional
+	// +kubebuilder:default="quay.io/podified-antelope-centos9/openstack-octavia-health-manager:current-podified"
+	// InitContainerImage - Rsyslog init Container Image URL for
+	InitContainerImage string `json:"initContainerImage,omitempty"`
 }
 
 // OctaviaRsyslogSpecCore -

--- a/config/crd/bases/octavia.openstack.org_octaviarsyslogs.yaml
+++ b/config/crd/bases/octavia.openstack.org_octaviarsyslogs.yaml
@@ -73,7 +73,7 @@ spec:
                 type: array
               containerImage:
                 default: quay.io/podified-antelope-centos9/openstack-rsyslog:current-podified
-                description: ContainerImage - Amphora Controller Container Image URL
+                description: ContainerImage - Rsyslog Container Image URL
                 type: string
               defaultConfigOverwrite:
                 additionalProperties:
@@ -83,6 +83,11 @@ spec:
                   But can also be used to add additional files. Those get added to the service config dir in /etc/<service> .
                   TODO: -> implement
                 type: object
+              initContainerImage:
+                default: quay.io/podified-antelope-centos9/openstack-octavia-health-manager:current-podified
+                description: InitContainerImage - Rsyslog init Container Image URL
+                  for
+                type: string
               networkAttachments:
                 default:
                 - octavia

--- a/config/crd/bases/octavia.openstack.org_octavias.yaml
+++ b/config/crd/bases/octavia.openstack.org_octavias.yaml
@@ -985,8 +985,7 @@ spec:
                     type: array
                   containerImage:
                     default: quay.io/podified-antelope-centos9/openstack-rsyslog:current-podified
-                    description: ContainerImage - Amphora Controller Container Image
-                      URL
+                    description: ContainerImage - Rsyslog Container Image URL
                     type: string
                   defaultConfigOverwrite:
                     additionalProperties:
@@ -996,6 +995,11 @@ spec:
                       But can also be used to add additional files. Those get added to the service config dir in /etc/<service> .
                       TODO: -> implement
                     type: object
+                  initContainerImage:
+                    default: quay.io/podified-antelope-centos9/openstack-octavia-health-manager:current-podified
+                    description: InitContainerImage - Rsyslog init Container Image
+                      URL for
+                    type: string
                   networkAttachments:
                     default:
                     - octavia

--- a/pkg/octaviarsyslog/daemonset.go
+++ b/pkg/octaviarsyslog/daemonset.go
@@ -118,11 +118,8 @@ func DaemonSet(
 					},
 					InitContainers: []corev1.Container{
 						{
-							Name: "init",
-							// TODO(gthiemonge) Using Octavia HM Container image is a workaround to get a container with pyroute2
-							// Replace it by an init container image with pyroute2 when it's available
-							// OSPRH-8434
-							Image: octaviav1.OctaviaHealthManagerContainerImage,
+							Name:  "init",
+							Image: instance.Spec.InitContainerImage,
 							SecurityContext: &corev1.SecurityContext{
 								RunAsUser: ptr.To(int64(0)),
 								Capabilities: &corev1.Capabilities{


### PR DESCRIPTION
The rsyslog init container image used directly an upstream image hostsed on quay, but it should rather use the override from the env var when available.

JIRA: [OSPRH-13530](https://issues.redhat.com//browse/OSPRH-13530)