### PR TITLE
Remove default annotations for images

### DIFF
--- a/api/bases/octavia.openstack.org_octaviarsyslogs.yaml
+++ b/api/bases/octavia.openstack.org_octaviarsyslogs.yaml
@@ -72,7 +72,6 @@ spec:
                   type: object
                 type: array
               containerImage:
-                default: quay.io/podified-antelope-centos9/openstack-rsyslog:current-podified
                 description: ContainerImage - Rsyslog Container Image URL
                 type: string
               defaultConfigOverwrite:
@@ -84,7 +83,6 @@ spec:
                   TODO: -> implement
                 type: object
               initContainerImage:
-                default: quay.io/podified-antelope-centos9/openstack-octavia-health-manager:current-podified
                 description: InitContainerImage - Rsyslog init Container Image URL
                   for
                 type: string

--- a/api/bases/octavia.openstack.org_octavias.yaml
+++ b/api/bases/octavia.openstack.org_octavias.yaml
@@ -1039,7 +1039,6 @@ spec:
                       type: object
                     type: array
                   containerImage:
-                    default: quay.io/podified-antelope-centos9/openstack-rsyslog:current-podified
                     description: ContainerImage - Rsyslog Container Image URL
                     type: string
                   defaultConfigOverwrite:
@@ -1051,7 +1050,6 @@ spec:
                       TODO: -> implement
                     type: object
                   initContainerImage:
-                    default: quay.io/podified-antelope-centos9/openstack-octavia-health-manager:current-podified
                     description: InitContainerImage - Rsyslog init Container Image
                       URL for
                     type: string

--- a/api/v1beta1/octaviarsyslog_types.go
+++ b/api/v1beta1/octaviarsyslog_types.go
@@ -28,12 +28,10 @@ type OctaviaRsyslogSpec struct {
 	OctaviaRsyslogSpecCore `json:",inline"`
 
 	// +kubebuilder:validation:Optional
-	// +kubebuilder:default="quay.io/podified-antelope-centos9/openstack-rsyslog:current-podified"
 	// ContainerImage - Rsyslog Container Image URL
 	ContainerImage string `json:"containerImage,omitempty"`
 
 	// +kubebuilder:validation:Optional
-	// +kubebuilder:default="quay.io/podified-antelope-centos9/openstack-octavia-health-manager:current-podified"
 	// InitContainerImage - Rsyslog init Container Image URL for
 	InitContainerImage string `json:"initContainerImage,omitempty"`
 }

--- a/config/crd/bases/octavia.openstack.org_octaviarsyslogs.yaml
+++ b/config/crd/bases/octavia.openstack.org_octaviarsyslogs.yaml
@@ -72,7 +72,6 @@ spec:
                   type: object
                 type: array
               containerImage:
-                default: quay.io/podified-antelope-centos9/openstack-rsyslog:current-podified
                 description: ContainerImage - Rsyslog Container Image URL
                 type: string
               defaultConfigOverwrite:
@@ -84,7 +83,6 @@ spec:
                   TODO: -> implement
                 type: object
               initContainerImage:
-                default: quay.io/podified-antelope-centos9/openstack-octavia-health-manager:current-podified
                 description: InitContainerImage - Rsyslog init Container Image URL
                   for
                 type: string

--- a/config/crd/bases/octavia.openstack.org_octavias.yaml
+++ b/config/crd/bases/octavia.openstack.org_octavias.yaml
@@ -1039,7 +1039,6 @@ spec:
                       type: object
                     type: array
                   containerImage:
-                    default: quay.io/podified-antelope-centos9/openstack-rsyslog:current-podified
                     description: ContainerImage - Rsyslog Container Image URL
                     type: string
                   defaultConfigOverwrite:
@@ -1051,7 +1050,6 @@ spec:
                       TODO: -> implement
                     type: object
                   initContainerImage:
-                    default: quay.io/podified-antelope-centos9/openstack-octavia-health-manager:current-podified
                     description: InitContainerImage - Rsyslog init Container Image
                       URL for
                     type: string


### PR DESCRIPTION
Patch removes the kubebuilder annotations for default container images as these are build/release dependent- not a function of the API.

Jira: [OSPRH-14716](https://issues.redhat.com//browse/OSPRH-14716)