### PR TITLE
Validate CA passphrase

### DIFF
--- a/tests/functional/base_test.go
+++ b/tests/functional/base_test.go
@@ -163,16 +163,20 @@ func CreateOctaviaSecret(namespace string) *corev1.Secret {
 	return secret
 }
 
-func CreateOctaviaCaPassphraseSecret(namespace string, name string) *corev1.Secret {
+func CreateOctaviaCaPassphraseSecretCustom(namespace string, name string, passphrase string) *corev1.Secret {
 	return th.CreateSecret(
 		types.NamespacedName{
 			Namespace: namespace,
 			Name:      fmt.Sprintf("%s-ca-passphrase", name),
 		},
 		map[string][]byte{
-			"server-ca-passphrase": []byte("12345678"),
+			"server-ca-passphrase": []byte(passphrase),
 		},
 	)
+}
+
+func CreateOctaviaCaPassphraseSecret(namespace string, name string) *corev1.Secret {
+	return CreateOctaviaCaPassphraseSecretCustom(namespace, name, "12345678")
 }
 
 func SimulateOctaviaCertsSecret(namespace string, name string) *corev1.Secret {


### PR DESCRIPTION
Add a validation step when fetching the CA passphrase from the secret, as the passphrase should be written in the octavia config files, we should ensure that it doesn't contain any non-printable characters (for instance \n)
If the passphrase includes non-printable characters, the decryption of the key might fail in octavia.

JIRA: [OSPRH-14829](https://issues.redhat.com//browse/OSPRH-14829)