### PR TITLE
Fix keypair being continuously deleted and created

### DIFF
--- a/tests/functional/base_test.go
+++ b/tests/functional/base_test.go
@@ -308,6 +308,6 @@ func CreateSSHPubKey() client.Object {
 		Name:      "octavia-ssh-pubkey",
 		Namespace: namespace,
 	}, map[string]interface{}{
-		"key": []byte("public key"),
+		"key": "public key",
 	})
 }

--- a/tests/functional/nova_api_fixture.go
+++ b/tests/functional/nova_api_fixture.go
@@ -65,7 +65,29 @@ func (f *NovaAPIFixture) keyPairHandler(w http.ResponseWriter, r *http.Request) 
 
 func (f *NovaAPIFixture) getKeyPair(w http.ResponseWriter, r *http.Request) {
 	items := strings.Split(r.URL.Path, "/")
-	if len(items) == 3 {
+	if len(items) == 4 {
+		var k struct {
+			KeyPair keypairs.KeyPair `json:"keypair"`
+		}
+		k.KeyPair = keypairs.KeyPair{}
+		query := r.URL.Query()
+		userID := query["user_id"]
+		keyName := items[3]
+		for _, keypair := range f.KeyPairs {
+			if userID[0] == keypair.UserID && keyName == keypair.Name {
+				k.KeyPair = keypair
+			}
+		}
+		bytes, err := json.Marshal(&k)
+		if err != nil {
+			f.InternalError(err, "Error during marshalling response", w, r)
+			return
+		}
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(200)
+		fmt.Fprint(w, string(bytes))
+	} else if len(items) == 3 {
 		type pair struct {
 			KeyPair keypairs.KeyPair `json:"keypair"`
 		}

--- a/tests/functional/octavia_controller_test.go
+++ b/tests/functional/octavia_controller_test.go
@@ -1043,7 +1043,7 @@ var _ = Describe("Octavia controller", func() {
 			apiFixtures.Nova.KeyPairs = map[string]keypairs.KeyPair{
 				"octavia-ssh-keypair": {
 					Name:      "octavia-ssh-keypair",
-					PublicKey: "foobar",
+					PublicKey: "public key",
 					UserID:    apiFixtures.Keystone.Users["octavia"].ID,
 				}}
 
@@ -1072,10 +1072,9 @@ var _ = Describe("Octavia controller", func() {
 			th.SimulateJobSuccess(octaviaDBSyncName)
 		})
 
-		// PENDING https://issues.redhat.com/browse/OSPRH-10543
-		PIt("should not update the keypair", func() {
+		It("should not update the keypair", func() {
 			keyPairs := apiFixtures.Nova.KeyPairs
-			Expect(keyPairs["octavia-ssh-keypair"].PublicKey).Should(Equal("foobar"))
+			Expect(keyPairs["octavia-ssh-keypair"].PublicKey).Should(Equal("public key"))
 		})
 	})
 


### PR DESCRIPTION
The Nova keypair was deleted and recreated each time we enter the reconcile loop.
Fixed this issue by changing the logic, enable the test that detected this issue

JIRA: [OSPRH-10543](https://issues.redhat.com//browse/OSPRH-10543)