### PR TITLE
Modernize Go code with latest style conventions

### DIFF
--- a/controllers/amphoracontroller_controller.go
+++ b/controllers/amphoracontroller_controller.go
@@ -20,6 +20,7 @@ package controllers
 import (
 	"context"
 	"fmt"
+	"maps"
 	"sort"
 	"strings"
 	"time"
@@ -572,9 +573,7 @@ func (r *OctaviaAmphoraControllerReconciler) generateServiceSecrets(
 		common.CustomServiceConfigFileName: instance.Spec.CustomServiceConfig,
 		"my.cnf":                           db.GetDatabaseClientConfig(tlsCfg), //(mschuppert) for now just get the default my.cnf
 	}
-	for key, data := range instance.Spec.DefaultConfigOverwrite {
-		customData[key] = data
-	}
+	maps.Copy(customData, instance.Spec.DefaultConfigOverwrite)
 
 	databaseAccount, dbSecret, err := mariadbv1.GetAccountAndSecret(
 		ctx, helper, instance.Spec.DatabaseAccount, instance.Namespace)
@@ -608,7 +607,7 @@ func (r *OctaviaAmphoraControllerReconciler) generateServiceSecrets(
 		mariadbv1.MariaDBAccountReadyCondition,
 		mariadbv1.MariaDBAccountReadyMessage)
 
-	templateParameters := map[string]interface{}{
+	templateParameters := map[string]any{
 		"DatabaseConnection": fmt.Sprintf("mysql+pymysql://%s:%s@%s/%s?read_default_file=/etc/my.cnf",
 			databaseAccount.Spec.UserName,
 			string(dbSecret.Data[mariadbv1.DatabasePasswordSelector]),

--- a/controllers/octavia_common.go
+++ b/controllers/octavia_common.go
@@ -25,7 +25,7 @@ import (
 
 type conditionUpdater interface {
 	Set(c *condition.Condition)
-	MarkTrue(t condition.Type, messageFormat string, messageArgs ...interface{})
+	MarkTrue(t condition.Type, messageFormat string, messageArgs ...any)
 }
 
 type topologyHandler interface {

--- a/controllers/octavia_controller.go
+++ b/controllers/octavia_controller.go
@@ -20,6 +20,7 @@ import (
 	"bufio"
 	"context"
 	"fmt"
+	"maps"
 	"net/http"
 	"sort"
 	"strings"
@@ -1435,9 +1436,7 @@ func (r *OctaviaReconciler) generateServiceSecrets(
 		common.CustomServiceConfigFileName: instance.Spec.CustomServiceConfig,
 		"my.cnf":                           octaviaDb.GetDatabaseClientConfig(tlsCfg), //(mschuppert) for now just get the default my.cnf
 	}
-	for key, data := range instance.Spec.DefaultConfigOverwrite {
-		customData[key] = data
-	}
+	maps.Copy(customData, instance.Spec.DefaultConfigOverwrite)
 
 	databaseAccount := octaviaDb.GetAccount()
 	dbSecret := octaviaDb.GetSecret()
@@ -1446,7 +1445,7 @@ func (r *OctaviaReconciler) generateServiceSecrets(
 
 	// We only need a minimal 00-config.conf that is only used by db-sync job,
 	// hence only passing the database related parameters
-	templateParameters := map[string]interface{}{
+	templateParameters := map[string]any{
 		"MinimalConfig": true, // This tells the template to generate a minimal config
 		"DatabaseConnection": fmt.Sprintf("mysql+pymysql://%s:%s@%s/%s?read_default_file=/etc/my.cnf",
 			databaseAccount.Spec.UserName,

--- a/controllers/octaviarsyslog_controller.go
+++ b/controllers/octaviarsyslog_controller.go
@@ -19,6 +19,7 @@ package controllers
 import (
 	"context"
 	"fmt"
+	"maps"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -428,11 +429,9 @@ func (r *OctaviaRsyslogReconciler) generateServiceSecrets(
 	cmLabels := labels.GetLabels(instance, labels.GetGroupLabel(instance.Name), map[string]string{})
 
 	customData := map[string]string{}
-	for key, data := range instance.Spec.DefaultConfigOverwrite {
-		customData[key] = data
-	}
+	maps.Copy(customData, instance.Spec.DefaultConfigOverwrite)
 
-	templateParameters := map[string]interface{}{}
+	templateParameters := map[string]any{}
 	templateParameters["AdminLogTargets"] = instance.Spec.AdminLogTargets
 	templateParameters["TenantLogTargets"] = instance.Spec.TenantLogTargets
 

--- a/pkg/octavia/amphora_certs.go
+++ b/pkg/octavia/amphora_certs.go
@@ -224,7 +224,7 @@ func EnsureAmphoraCerts(
 				"client_ca.cert.pem": clientCACert,
 				// Unencrypted client key and cert
 				"client.cert-and-key.pem": clientKeyAndCert,
-				"version":                 []byte(fmt.Sprintf("%d", OctaviaCertSecretVersion)),
+				"version":                 fmt.Appendf(nil, "%d", OctaviaCertSecretVersion),
 			},
 		}
 

--- a/pkg/octavia/lb_mgmt_network.go
+++ b/pkg/octavia/lb_mgmt_network.go
@@ -1123,7 +1123,7 @@ func GetPredictableIPAM(networkParameters *NetworkParameters) (*NADIpam, error) 
 	predParams.CIDR = networkParameters.ProviderCIDR
 	predParams.RangeStart = networkParameters.ProviderAllocationEnd.Next()
 	endRange := predParams.RangeStart
-	for i := 0; i < LbProvPredictablePoolSize; i++ {
+	for range LbProvPredictablePoolSize {
 		if !predParams.CIDR.Contains(endRange) {
 			return nil, fmt.Errorf("%w: %d in %s", ErrPredictableIPAllocation, LbProvPredictablePoolSize, predParams.CIDR)
 		}

--- a/pkg/octavia/network_parameters.go
+++ b/pkg/octavia/network_parameters.go
@@ -59,7 +59,7 @@ func GetRangeFromCIDR(
 ) (start netip.Addr, end netip.Addr) {
 	// start is the 5th address of the Cidr
 	start = cidr.Masked().Addr()
-	for i := 0; i < 5; i++ {
+	for range 5 {
 		start = start.Next()
 	}
 
@@ -108,7 +108,7 @@ func GetNetworkParametersFromNAD(
 	// RangeEnd.
 	networkParameters.ProviderAllocationStart = nadConfig.IPAM.RangeEnd.Next()
 	end := networkParameters.ProviderAllocationStart
-	for i := 0; i < LbProvSubnetPoolSize; i++ {
+	for range LbProvSubnetPoolSize {
 		if !networkParameters.ProviderCIDR.Contains(end) {
 			return nil, fmt.Errorf("%w: %d in %s", ErrCannotAllocateIPAddresses, LbProvSubnetPoolSize, networkParameters.ProviderCIDR)
 		}

--- a/tests/functional/base_test.go
+++ b/tests/functional/base_test.go
@@ -71,7 +71,7 @@ func CreateTransportURLSecret(name types.NamespacedName) *corev1.Secret {
 	secret := th.CreateSecret(
 		name,
 		map[string][]byte{
-			"transport_url": []byte(fmt.Sprintf("rabbit://%s/", name)),
+			"transport_url": fmt.Appendf(nil, "rabbit://%s/", name),
 		},
 	)
 	logger.Info("Created TransportURLSecret", "secret", secret)
@@ -107,14 +107,14 @@ func SimulateKeystoneReady(
 	}, timeout, interval).Should(Succeed())
 }
 
-func GetDefaultOctaviaSpec() map[string]interface{} {
-	return map[string]interface{}{
+func GetDefaultOctaviaSpec() map[string]any {
+	return map[string]any{
 		"databaseInstance":           "test-octavia-db-instance",
 		"secret":                     SecretName,
 		"octaviaNetworkAttachment":   "octavia-attachement",
 		"databaseAccount":            "octavia-db-account",
 		"persistenceDatabaseAccount": "octavia-persistence-db-account",
-		"lbMgmtNetwork": map[string]interface{}{
+		"lbMgmtNetwork": map[string]any{
 			"availabilityZones": []string{"az0"},
 			// It seems that the functional tests don't use the correct default
 			// values for nested structures, when the default is defined in the
@@ -125,12 +125,12 @@ func GetDefaultOctaviaSpec() map[string]interface{} {
 	}
 }
 
-func CreateOctavia(name types.NamespacedName, spec map[string]interface{}) client.Object {
+func CreateOctavia(name types.NamespacedName, spec map[string]any) client.Object {
 
-	raw := map[string]interface{}{
+	raw := map[string]any{
 		"apiVersion": "octavia.openstack.org/v1beta1",
 		"kind":       "Octavia",
-		"metadata": map[string]interface{}{
+		"metadata": map[string]any{
 			"name":      name.Name,
 			"namespace": name.Namespace,
 		},
@@ -198,8 +198,8 @@ func SimulateOctaviaCertsSecret(namespace string, name string) *corev1.Secret {
 }
 
 // OctaviaAPI
-func GetDefaultOctaviaAPISpec() map[string]interface{} {
-	return map[string]interface{}{
+func GetDefaultOctaviaAPISpec() map[string]any {
+	return map[string]any{
 		"databaseHostname": "hostname-for-octavia-api",
 		"databaseInstance": "test-octavia-db-instance",
 		"secret":           SecretName,
@@ -208,11 +208,11 @@ func GetDefaultOctaviaAPISpec() map[string]interface{} {
 	}
 }
 
-func CreateOctaviaAPI(name types.NamespacedName, spec map[string]interface{}) client.Object {
-	raw := map[string]interface{}{
+func CreateOctaviaAPI(name types.NamespacedName, spec map[string]any) client.Object {
+	raw := map[string]any{
 		"apiVersion": "octavia.openstack.org/v1beta1",
 		"kind":       "OctaviaAPI",
-		"metadata": map[string]interface{}{
+		"metadata": map[string]any{
 			"name":      name.Name,
 			"namespace": name.Namespace,
 		},
@@ -244,14 +244,14 @@ func SimulateOctaviaAPIReady(name types.NamespacedName) {
 }
 
 func CreateNAD(name types.NamespacedName) client.Object {
-	raw := map[string]interface{}{
+	raw := map[string]any{
 		"apiVersion": "k8s.cni.cncf.io/v1",
 		"kind":       "NetworkAttachmentDefinition",
-		"metadata": map[string]interface{}{
+		"metadata": map[string]any{
 			"name":      name.Name,
 			"namespace": name.Namespace,
 		},
-		"spec": map[string]interface{}{
+		"spec": map[string]any{
 			"config": `{
 				"cniVersion": "0.3.1",
 				"name": "octavia",
@@ -290,14 +290,14 @@ func GetNADConfig(name types.NamespacedName) *octavia.NADConfig {
 }
 
 func CreateNode(name types.NamespacedName) client.Object {
-	raw := map[string]interface{}{
+	raw := map[string]any{
 		"apiVersion": "v1",
 		"kind":       "Node",
-		"metadata": map[string]interface{}{
+		"metadata": map[string]any{
 			"name":      name.Name,
 			"namespace": name.Namespace,
 		},
-		"spec": map[string]interface{}{},
+		"spec": map[string]any{},
 	}
 	return th.CreateUnstructured(raw)
 
@@ -307,7 +307,7 @@ func CreateSSHPubKey() client.Object {
 	return th.CreateConfigMap(types.NamespacedName{
 		Name:      "octavia-ssh-pubkey",
 		Namespace: namespace,
-	}, map[string]interface{}{
+	}, map[string]any{
 		"key": "public key",
 	})
 }

--- a/tests/functional/octavia_controller_test.go
+++ b/tests/functional/octavia_controller_test.go
@@ -74,7 +74,7 @@ func createAndSimulateTransportURL(
 	infra.SimulateTransportURLReady(transportURLName)
 }
 
-func createAndSimulateDB(spec map[string]interface{}) {
+func createAndSimulateDB(spec map[string]any) {
 	DeferCleanup(
 		mariadb.DeleteDBService,
 		mariadb.CreateDBService(
@@ -112,7 +112,7 @@ func createAndSimulateOctaviaAPI(octaviaName types.NamespacedName) {
 
 var _ = Describe("Octavia controller", func() {
 	var name string
-	var spec map[string]interface{}
+	var spec map[string]any
 	var octaviaName types.NamespacedName
 	var transportURLName types.NamespacedName
 	var transportURLSecretName types.NamespacedName
@@ -705,11 +705,11 @@ var _ = Describe("Octavia controller", func() {
 				Name:      "node1",
 			}))
 
-			spec["lbMgmtNetwork"].(map[string]interface{})["availabilityZoneCIDRs"] = map[string]string{
+			spec["lbMgmtNetwork"].(map[string]any)["availabilityZoneCIDRs"] = map[string]string{
 				"az1": "172.34.0.0/16",
 				"az2": "172.44.8.0/21",
 			}
-			spec["lbMgmtNetwork"].(map[string]interface{})["createDefaultLbMgmtNetwork"] = false
+			spec["lbMgmtNetwork"].(map[string]any)["createDefaultLbMgmtNetwork"] = false
 			DeferCleanup(th.DeleteInstance, CreateOctavia(octaviaName, spec))
 
 			th.SimulateJobSuccess(octaviaDBSyncName)
@@ -886,7 +886,7 @@ var _ = Describe("Octavia controller", func() {
 
 	When("Octavia is created with nodeSelector", func() {
 		BeforeEach(func() {
-			spec["nodeSelector"] = map[string]interface{}{
+			spec["nodeSelector"] = map[string]any{
 				"foo": "bar",
 			}
 
@@ -1088,24 +1088,24 @@ var _ = Describe("Octavia controller", func() {
 
 			// API, Worker and KeystoneListener
 			if component != "top-level" {
-				spec[component] = map[string]interface{}{
-					"topologyRef": map[string]interface{}{
+				spec[component] = map[string]any{
+					"topologyRef": map[string]any{
 						"name":      "bar",
 						"namespace": "foo",
 					},
 				}
 				// top-level topologyRef
 			} else {
-				spec["topologyRef"] = map[string]interface{}{
+				spec["topologyRef"] = map[string]any{
 					"name":      "bar",
 					"namespace": "foo",
 				}
 			}
 			// Build the octavia CR
-			raw := map[string]interface{}{
+			raw := map[string]any{
 				"apiVersion": "octavia.openstack.org/v1beta1",
 				"kind":       "Octavia",
-				"metadata": map[string]interface{}{
+				"metadata": map[string]any{
 					"name":      octaviaName.Name,
 					"namespace": octaviaName.Namespace,
 				},

--- a/tests/functional/octaviaapi_controller_test.go
+++ b/tests/functional/octaviaapi_controller_test.go
@@ -37,7 +37,7 @@ import (
 
 var _ = Describe("OctaviaAPI controller", func() {
 	var name string
-	var spec map[string]interface{}
+	var spec map[string]any
 	var octaviaAPIName types.NamespacedName
 	var transportURLSecretName types.NamespacedName
 


### PR DESCRIPTION
Modernize using `gopls modernize tool` to update:

- Replace interface{} with any type alias (Go 1.18+)
- Update range loops to use idiomatic range syntax
- Replace fmt.Sprintf with fmt.Appendf where appropriate

These changes improve code readability and align with current Go best practices.

Co-Authored-By: Claude <noreply@anthropic.com>