### PR TITLE
Remove duplicate Auth spec from OctaviaAPI and AmphoraController core types

### DIFF
--- a/api/v1beta1/amphoracontroller_types.go
+++ b/api/v1beta1/amphoracontroller_types.go
@@ -41,6 +41,11 @@ type OctaviaAmphoraControllerSpec struct {
 	// +kubebuilder:validation:Optional
 	// ContainerImage - Amphora Controller Container Image URL
 	ContainerImage string `json:"containerImage,omitempty"`
+
+	// +kubebuilder:validation:Optional
+	// +operator-sdk:csv:customresourcedefinitions:type=spec
+	// Auth - Parameters related to authentication, propagated from the parent Octavia CR
+	Auth AuthSpec `json:"auth,omitempty"`
 }
 
 // OctaviaAmphoraControllerSpecCore -
@@ -176,10 +181,6 @@ type OctaviaAmphoraControllerSpecCore struct {
 	// by name
 	TopologyRef *topologyv1.TopoRef `json:"topologyRef,omitempty"`
 
-	// +kubebuilder:validation:Optional
-	// +operator-sdk:csv:customresourcedefinitions:type=spec
-	// Auth - Parameters related to authentication
-	Auth AuthSpec `json:"auth,omitempty"`
 }
 
 // OctaviaAmphoraControllerStatus defines the observed state of the Octavia Amphora Controller

--- a/api/v1beta1/octavia_types.go
+++ b/api/v1beta1/octavia_types.go
@@ -248,6 +248,14 @@ type OctaviaSpecBase struct {
 	Auth AuthSpec `json:"auth,omitempty"`
 }
 
+// AuthSpec defines authentication parameters
+type AuthSpec struct {
+	// +kubebuilder:validation:Optional
+	// +operator-sdk:csv:customresourcedefinitions:type=spec
+	// ApplicationCredentialSecret - Secret containing Application Credential ID and Secret
+	ApplicationCredentialSecret string `json:"applicationCredentialSecret,omitempty"`
+}
+
 // PasswordSelector to identify the DB and AdminUser password from the Secret
 type PasswordSelector struct {
 	// +kubebuilder:validation:Optional

--- a/api/v1beta1/octaviaapi_types.go
+++ b/api/v1beta1/octaviaapi_types.go
@@ -46,6 +46,11 @@ type OctaviaAPISpec struct {
 	// +kubebuilder:validation:Required
 	// Octavia Container Image URL
 	ContainerImage string `json:"containerImage"`
+
+	// +kubebuilder:validation:Optional
+	// +operator-sdk:csv:customresourcedefinitions:type=spec
+	// Auth - Parameters related to authentication, propagated from the parent Octavia CR
+	Auth AuthSpec `json:"auth,omitempty"`
 }
 
 // OctaviaAPISpecCore -
@@ -159,11 +164,6 @@ type OctaviaAPISpecCore struct {
 	TLS OctaviaApiTLS `json:"tls,omitempty"`
 
 	// +kubebuilder:validation:Optional
-	// +operator-sdk:csv:customresourcedefinitions:type=spec
-	// Auth - Parameters related to authentication
-	Auth AuthSpec `json:"auth,omitempty"`
-
-	// +kubebuilder:validation:Optional
 	// APITimeout for HAProxy and Apache defaults to OctaviaSpecCore APITimeout (seconds)
 	APITimeout int `json:"apiTimeout"`
 
@@ -195,13 +195,6 @@ type APIOverrideSpec struct {
 	Service map[service.Endpoint]service.RoutedOverrideSpec `json:"service,omitempty"`
 }
 
-// AuthSpec defines authentication parameters
-type AuthSpec struct {
-	// +kubebuilder:validation:Optional
-	// +operator-sdk:csv:customresourcedefinitions:type=spec
-	// ApplicationCredentialSecret - Secret containing Application Credential ID and Secret
-	ApplicationCredentialSecret string `json:"applicationCredentialSecret,omitempty"`
-}
 
 // OctaviaAPIStatus defines the observed state of OctaviaAPI
 type OctaviaAPIStatus struct {


### PR DESCRIPTION
The Auth field with ApplicationCredentialSecret was defined in three places: OctaviaSpecBase (correct), OctaviaAPISpecCore (duplicate), and OctaviaAmphoraControllerSpecCore (duplicate).

The duplicate fields in the *SpecCore types are exposed to the openstack-operator, which led to the app cred secret being set on OctaviaAPI.Auth instead of the top-level Auth ([OSPRH-26817](https://issues.redhat.com/browse/OSPRH-26817)).

Move Auth from *SpecCore types to the full *Spec types so that:
- The openstack-operator CRD only exposes Auth at the top level
- Internal propagation from parent Octavia CR to sub-resources still works via the full Spec types
- AuthSpec type definition moved to octavia_types.go where the primary Auth field is defined

Co-authored-by: AI Assistant (Cursor/Claude)
JIRA: [OSPRH-26817](https://issues.redhat.com/browse/OSPRH-26817)