### PR TITLE
Fix condition where Octavia Provder Router might be missing port info

### DIFF
--- a/internal/octavia/lb_mgmt_network.go
+++ b/internal/octavia/lb_mgmt_network.go
@@ -1073,8 +1073,7 @@ func EnsureAmphoraManagementNetwork(
 			if err != nil {
 				log.Error(err, fmt.Sprintf("Unable to add interface port %s to router %s", tenantRouterPort.ID, router.ID))
 			}
-		}
-		else {
+		} else {
 			log.Info("Octavia provider router already has interface info defined")
 		}
 	}

--- a/internal/octavia/lb_mgmt_network.go
+++ b/internal/octavia/lb_mgmt_network.go
@@ -1073,8 +1073,6 @@ func EnsureAmphoraManagementNetwork(
 			if err != nil {
 				log.Error(err, fmt.Sprintf("Unable to add interface port %s to router %s", tenantRouterPort.ID, router.ID))
 			}
-		} else {
-			log.Info("Octavia provider router already has interface info defined")
 		}
 	}
 

--- a/test/functional/neutron_api_fixture.go
+++ b/test/functional/neutron_api_fixture.go
@@ -435,6 +435,7 @@ func (f *NeutronAPIFixture) getPort(w http.ResponseWriter, r *http.Request) {
 		name := query["name"]
 		tenantID := query["tenant_id"]
 		networkID := query["network_id"]
+		deviceID := query["device_id"]
 		for _, port := range f.Ports {
 			if len(name) > 0 && name[0] != port.Name {
 				continue
@@ -443,6 +444,9 @@ func (f *NeutronAPIFixture) getPort(w http.ResponseWriter, r *http.Request) {
 				continue
 			}
 			if len(networkID) > 0 && networkID[0] != port.NetworkID {
+				continue
+			}
+			if len(deviceID) > 0 && deviceID[0] != port.DeviceID {
 				continue
 			}
 			n.Ports = append(n.Ports, port)
@@ -610,6 +614,12 @@ func (f *NeutronAPIFixture) putRouter(w http.ResponseWriter, r *http.Request) {
 		f.InterfaceInfos[fmt.Sprintf("%s:%s", routerID, subnetID)] = routers.InterfaceInfo{
 			SubnetID: subnetID,
 			PortID:   n.PortID,
+		}
+
+		// Update the port's DeviceID to reflect it's attached to this router
+		if port, ok := f.Ports[n.PortID]; ok {
+			port.DeviceID = routerID
+			f.Ports[n.PortID] = port
 		}
 
 		bytes, err = json.Marshal(&n)


### PR DESCRIPTION
- If the creation of the Octavia provider router fails for any reason (e.g. Neutron timeout) then the port info won't be set
- On the next pass of the controller, it will see the router exists and reconcile it
- This skips the setting of the port info, so that will be missing
- This change extracts that setting to a separate step
- Checks are added to determine if the port info has already been set before trying to add it
- Unit tests are updated

Signed-off-by: Richard Cruise <rcruise@redhat.com>
Assisted-by: Claude Code <https://claude.ai/>