### PR TITLE
Move to VerifySecretFields to reject invalid passwords

### DIFF
--- a/test/functional/base_test.go
+++ b/test/functional/base_test.go
@@ -311,3 +311,13 @@ func CreateSSHPubKey() client.Object {
 		"key": "public key",
 	})
 }
+
+// CreateOctaviaInvalidSecret creates a secret with an invalid password for testing
+func CreateOctaviaInvalidSecret(namespace string, name string) *corev1.Secret {
+	return th.CreateSecret(
+		types.NamespacedName{Namespace: namespace, Name: name},
+		map[string][]byte{
+			"OctaviaPassword": []byte("c^sometext02%text%text02$someText&"),
+		},
+	)
+}


### PR DESCRIPTION
`Service` passwords are usually defined in the `osp-secret` and propagated to their config. This patch moves from `verifyServiceSecret` to the new lib-common `VerifySecretFields`, that calls a validator to accept/reject the password field and set the appropriate `errorMsg` to the `InputReady` `Condition`.

Jira: https://issues.redhat.com/browse/OSPRH-26429