### PR TITLE
Add createFlavors flag to control Octavia flavor creation

### DIFF
--- a/api/bases/octavia.openstack.org_octaviaamphoracontrollers.yaml
+++ b/api/bases/octavia.openstack.org_octaviaamphoracontrollers.yaml
@@ -93,6 +93,16 @@ spec:
               containerImage:
                 description: ContainerImage - Amphora Controller Container Image URL
                 type: string
+              createFlavors:
+                description: |-
+                  CreateFlavors - when enabled or empty (default), octavia-operator creates Octavia
+                  flavors and flavor profiles. Set to disabled to manage Octavia flavors externally.
+                  Note: Nova compute flavors for amphorae are always created regardless of this setting.
+                enum:
+                - enabled
+                - disabled
+                - ""
+                type: string
               customServiceConfig:
                 default: '# add your customization here'
                 description: |-

--- a/api/bases/octavia.openstack.org_octavias.yaml
+++ b/api/bases/octavia.openstack.org_octavias.yaml
@@ -92,6 +92,16 @@ spec:
                       Credential ID and Secret
                     type: string
                 type: object
+              createFlavors:
+                description: |-
+                  CreateFlavors - when enabled or empty (default), octavia-operator creates Octavia
+                  flavors and flavor profiles. Set to disabled to manage Octavia flavors externally.
+                  Note: Nova compute flavors for amphorae are always created regardless of this setting.
+                enum:
+                - enabled
+                - disabled
+                - ""
+                type: string
               customServiceConfig:
                 default: '# add your customization here'
                 description: |-
@@ -648,6 +658,16 @@ spec:
                     description: ContainerImage - Amphora Controller Container Image
                       URL
                     type: string
+                  createFlavors:
+                    description: |-
+                      CreateFlavors - when enabled or empty (default), octavia-operator creates Octavia
+                      flavors and flavor profiles. Set to disabled to manage Octavia flavors externally.
+                      Note: Nova compute flavors for amphorae are always created regardless of this setting.
+                    enum:
+                    - enabled
+                    - disabled
+                    - ""
+                    type: string
                   customServiceConfig:
                     default: '# add your customization here'
                     description: |-
@@ -907,6 +927,16 @@ spec:
                   containerImage:
                     description: ContainerImage - Amphora Controller Container Image
                       URL
+                    type: string
+                  createFlavors:
+                    description: |-
+                      CreateFlavors - when enabled or empty (default), octavia-operator creates Octavia
+                      flavors and flavor profiles. Set to disabled to manage Octavia flavors externally.
+                      Note: Nova compute flavors for amphorae are always created regardless of this setting.
+                    enum:
+                    - enabled
+                    - disabled
+                    - ""
                     type: string
                   customServiceConfig:
                     default: '# add your customization here'
@@ -1343,6 +1373,16 @@ spec:
                   containerImage:
                     description: ContainerImage - Amphora Controller Container Image
                       URL
+                    type: string
+                  createFlavors:
+                    description: |-
+                      CreateFlavors - when enabled or empty (default), octavia-operator creates Octavia
+                      flavors and flavor profiles. Set to disabled to manage Octavia flavors externally.
+                      Note: Nova compute flavors for amphorae are always created regardless of this setting.
+                    enum:
+                    - enabled
+                    - disabled
+                    - ""
                     type: string
                   customServiceConfig:
                     default: '# add your customization here'

--- a/api/v1beta1/amphoracontroller_types.go
+++ b/api/v1beta1/amphoracontroller_types.go
@@ -147,6 +147,13 @@ type OctaviaAmphoraControllerSpecCore struct {
 	AmphoraCustomFlavors []OctaviaAmphoraFlavor `json:"amphoraCustomFlavors,omitempty"`
 
 	// +kubebuilder:validation:Optional
+	// +kubebuilder:validation:Enum=enabled;disabled;"";
+	// CreateFlavors - when enabled or empty (default), octavia-operator creates Octavia
+	// flavors and flavor profiles. Set to disabled to manage Octavia flavors externally.
+	// Note: Nova compute flavors for amphorae are always created regardless of this setting.
+	CreateFlavors string `json:"createFlavors,omitempty"`
+
+	// +kubebuilder:validation:Optional
 	// +kubebuilder:default=""
 	AmphoraImageOwnerID string `json:"amphoraImageOwnerID,omitempty"`
 

--- a/api/v1beta1/octavia_types.go
+++ b/api/v1beta1/octavia_types.go
@@ -210,6 +210,13 @@ type OctaviaSpecBase struct {
 	AmphoraCustomFlavors []OctaviaAmphoraFlavor `json:"amphoraCustomFlavors,omitempty"`
 
 	// +kubebuilder:validation:Optional
+	// +kubebuilder:validation:Enum=enabled;disabled;"";
+	// CreateFlavors - when enabled or empty (default), octavia-operator creates Octavia
+	// flavors and flavor profiles. Set to disabled to manage Octavia flavors externally.
+	// Note: Nova compute flavors for amphorae are always created regardless of this setting.
+	CreateFlavors string `json:"createFlavors,omitempty"`
+
+	// +kubebuilder:validation:Optional
 	// Resources - Compute Resources required by this service (Limits/Requests).
 	// https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
 	Resources corev1.ResourceRequirements `json:"resources,omitempty"`

--- a/config/crd/bases/octavia.openstack.org_octaviaamphoracontrollers.yaml
+++ b/config/crd/bases/octavia.openstack.org_octaviaamphoracontrollers.yaml
@@ -93,6 +93,16 @@ spec:
               containerImage:
                 description: ContainerImage - Amphora Controller Container Image URL
                 type: string
+              createFlavors:
+                description: |-
+                  CreateFlavors - when enabled or empty (default), octavia-operator creates Octavia
+                  flavors and flavor profiles. Set to disabled to manage Octavia flavors externally.
+                  Note: Nova compute flavors for amphorae are always created regardless of this setting.
+                enum:
+                - enabled
+                - disabled
+                - ""
+                type: string
               customServiceConfig:
                 default: '# add your customization here'
                 description: |-

--- a/config/crd/bases/octavia.openstack.org_octavias.yaml
+++ b/config/crd/bases/octavia.openstack.org_octavias.yaml
@@ -92,6 +92,16 @@ spec:
                       Credential ID and Secret
                     type: string
                 type: object
+              createFlavors:
+                description: |-
+                  CreateFlavors - when enabled or empty (default), octavia-operator creates Octavia
+                  flavors and flavor profiles. Set to disabled to manage Octavia flavors externally.
+                  Note: Nova compute flavors for amphorae are always created regardless of this setting.
+                enum:
+                - enabled
+                - disabled
+                - ""
+                type: string
               customServiceConfig:
                 default: '# add your customization here'
                 description: |-
@@ -648,6 +658,16 @@ spec:
                     description: ContainerImage - Amphora Controller Container Image
                       URL
                     type: string
+                  createFlavors:
+                    description: |-
+                      CreateFlavors - when enabled or empty (default), octavia-operator creates Octavia
+                      flavors and flavor profiles. Set to disabled to manage Octavia flavors externally.
+                      Note: Nova compute flavors for amphorae are always created regardless of this setting.
+                    enum:
+                    - enabled
+                    - disabled
+                    - ""
+                    type: string
                   customServiceConfig:
                     default: '# add your customization here'
                     description: |-
@@ -907,6 +927,16 @@ spec:
                   containerImage:
                     description: ContainerImage - Amphora Controller Container Image
                       URL
+                    type: string
+                  createFlavors:
+                    description: |-
+                      CreateFlavors - when enabled or empty (default), octavia-operator creates Octavia
+                      flavors and flavor profiles. Set to disabled to manage Octavia flavors externally.
+                      Note: Nova compute flavors for amphorae are always created regardless of this setting.
+                    enum:
+                    - enabled
+                    - disabled
+                    - ""
                     type: string
                   customServiceConfig:
                     default: '# add your customization here'
@@ -1343,6 +1373,16 @@ spec:
                   containerImage:
                     description: ContainerImage - Amphora Controller Container Image
                       URL
+                    type: string
+                  createFlavors:
+                    description: |-
+                      CreateFlavors - when enabled or empty (default), octavia-operator creates Octavia
+                      flavors and flavor profiles. Set to disabled to manage Octavia flavors externally.
+                      Note: Nova compute flavors for amphorae are always created regardless of this setting.
+                    enum:
+                    - enabled
+                    - disabled
+                    - ""
                     type: string
                   customServiceConfig:
                     default: '# add your customization here'

--- a/internal/amphoracontrollers/flavors.go
+++ b/internal/amphoracontrollers/flavors.go
@@ -128,14 +128,20 @@ func getOctaviaFlavors(ctx context.Context, lbClient *gophercloud.ServiceClient)
 }
 
 func ensureFlavors(ctx context.Context, osclient *openstack.OpenStack, log *logr.Logger, instance *octaviav1.OctaviaAmphoraController) (string, error) {
+	// Default to enabled if empty or "enabled", only skip if explicitly "disabled"
+	createOctaviaFlavors := instance.Spec.CreateFlavors != "disabled"
+
 	computeClient, err := octavia.GetComputeClient(osclient)
 	if err != nil {
 		return "", fmt.Errorf("error getting compute client: %w", err)
 	}
 
-	lbClient, err := octavia.GetLoadBalancerClient(osclient)
-	if err != nil {
-		return "", fmt.Errorf("error getting loadbalancer client: %w", err)
+	var lbClient *gophercloud.ServiceClient
+	if createOctaviaFlavors {
+		lbClient, err = octavia.GetLoadBalancerClient(osclient)
+		if err != nil {
+			return "", fmt.Errorf("error getting loadbalancer client: %w", err)
+		}
 	}
 
 	amphoraFlavors, err := getAmphoraFlavors(ctx, computeClient)
@@ -196,6 +202,12 @@ func ensureFlavors(ctx context.Context, osclient *openstack.OpenStack, log *logr
 				defaultFlavorID = flavor.ID
 			}
 		}
+	}
+
+	// Skip Octavia flavor profiles and flavors creation if disabled
+	if !createOctaviaFlavors {
+		log.Info("Octavia flavor/flavor profile creation is disabled (createFlavors: disabled)")
+		return defaultFlavorID, nil
 	}
 
 	// Get Octavia FlavorProfiles and Flavors
@@ -295,7 +307,8 @@ func ensureFlavors(ctx context.Context, osclient *openstack.OpenStack, log *logr
 	return defaultFlavorID, nil
 }
 
-// EnsureFlavors - enable that the Nova flavors for the amphora VMs are created
+// EnsureFlavors - ensures that the Nova flavors for the amphora VMs are created.
+// When spec.CreateFlavors is "enabled" or empty (default), it also creates Octavia flavor profiles and flavors.
 //
 // returns the UUID of the default Nova flavor
 func EnsureFlavors(ctx context.Context, instance *octaviav1.OctaviaAmphoraController, log *logr.Logger, helper *helper.Helper) (string, error) {

--- a/internal/controller/octavia_controller.go
+++ b/internal/controller/octavia_controller.go
@@ -1744,6 +1744,7 @@ func (r *OctaviaReconciler) amphoraControllerDaemonSetCreateOrUpdate(
 		daemonset.Spec.LbMgmtNetworkID = networkInfo.TenantNetworkID
 		daemonset.Spec.LbSecurityGroupID = networkInfo.SecurityGroupID
 		daemonset.Spec.AmphoraCustomFlavors = instance.Spec.AmphoraCustomFlavors
+		daemonset.Spec.CreateFlavors = instance.Spec.CreateFlavors
 		daemonset.Spec.RedisHosts = instance.Status.RedisHosts
 		daemonset.Spec.TLS = instance.Spec.OctaviaAPI.TLS.Ca
 		daemonset.Spec.AmphoraImageOwnerID = ampImageOwnerID


### PR DESCRIPTION
Add a new boolean field `createFlavors` (default: true) to OctaviaSpec that controls whether Octavia flavors and flavor profiles are created.

When set to false:
- Nova compute flavors for amphorae are still created (needed for config)
- Octavia flavor profiles and flavors are skipped

This allows users to manage Octavia flavors externally while still having the operator handle Nova compute flavors automatically.

JIRA: [OSPRH-30649](https://redhat.atlassian.net/browse/OSPRH-30649)