### PR TITLE
Set ImagePullPolicy to IfNotPresent on image upload deployment

### DIFF
--- a/internal/octavia/image_upload_deployment.go
+++ b/internal/octavia/image_upload_deployment.go
@@ -117,10 +117,11 @@ func ImageUploadDeployment(
 							Command: []string{
 								"/bin/bash",
 							},
-							Args:         args,
-							Image:        instance.Spec.ApacheContainerImage,
-							VolumeMounts: getVolumeMounts(),
-							Resources:    instance.Spec.Resources,
+							Args:            args,
+							Image:           instance.Spec.ApacheContainerImage,
+							ImagePullPolicy: corev1.PullIfNotPresent,
+							VolumeMounts:    getVolumeMounts(),
+							Resources:       instance.Spec.Resources,
 							// TODO(gthiemonge) do we need probes?
 						},
 					},
@@ -154,8 +155,9 @@ func initContainer(init ImageUploadDetails) []corev1.Container {
 
 	return []corev1.Container{
 		{
-			Name:  "init",
-			Image: init.ContainerImage,
+			Name:            "init",
+			Image:           init.ContainerImage,
+			ImagePullPolicy: corev1.PullIfNotPresent,
 			SecurityContext: &corev1.SecurityContext{
 				RunAsUser: &runAsUser,
 			},


### PR DESCRIPTION
The image upload deployment containers did not explicitly set ImagePullPolicy. When the image tag is "latest" or unset, Kubernetes defaults the pull policy to Always, resulting in unnecessary image pulls on every pod restart. Explicitly set PullIfNotPresent on both the main httpd container and the init container.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>