### PR TITLE
Set service_type in [keystone_authtoken] for access rule validation

### DIFF
--- a/templates/octaviaapi/config/octavia.conf
+++ b/templates/octaviaapi/config/octavia.conf
@@ -37,6 +37,7 @@ user_domain_name=Default
 region_name={{ .Region }}
 {{ end -}}
 interface=internal
+service_type=load-balancer
 [certificates]
 # ca_certificate=/etc/octavia/certs/ca_01.pem
 # ca_private_key=/etc/octavia/certs/private/cakey.pem


### PR DESCRIPTION
Without service_type configured, keystonemiddleware cannot validate application credentials with custom access rules, causing HTTP 401 for end users.

Closes: [OSPRH-22365](https://redhat.atlassian.net/browse/OSPRH-22365)