### PR TITLE
Remove deprecated webhook.Defaulter/Validator interface assertions

### DIFF
--- a/api/v1beta1/octavia_webhook.go
+++ b/api/v1beta1/octavia_webhook.go
@@ -27,7 +27,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
-	"sigs.k8s.io/controller-runtime/pkg/webhook"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
 
@@ -52,8 +51,6 @@ func SetupOctaviaDefaults(defaults OctaviaDefaults) {
 	octaviaDefaults = defaults
 	octavialog.Info("Octavia defaults initialized", "defaults", defaults)
 }
-
-var _ webhook.Defaulter = &Octavia{}
 
 // Default implements webhook.Defaulter so a webhook will be registered for the type
 func (r *Octavia) Default() {
@@ -104,8 +101,6 @@ func (spec *OctaviaSpecCore) Default() {
 		spec.MessagingBus.Cluster = "rabbitmq"
 	}
 }
-
-var _ webhook.Validator = &Octavia{}
 
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type
 func (r *Octavia) ValidateCreate() (admission.Warnings, error) {


### PR DESCRIPTION
These compile-time assertions reference webhook.Defaulter and webhook.Validator interfaces that are removed in controller-runtime v0.21 (OCP 4.20). The assertions are dead code — webhook registration already uses CustomDefaulter/CustomValidator in internal/webhook/.

Removing them makes the API module forward-compatible with CR v0.21 so that consumers (like openstack-operator) can bump controller-runtime without needing replace directives for this operator.

Jira: [OSPRH-32989](https://redhat.atlassian.net/browse/OSPRH-32989)