### PR TITLE
Remove unnecessary pods RBAC permissions

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -8,7 +8,6 @@ rules:
   - ""
   resources:
   - configmaps
-  - pods
   - secrets
   - services
   verbs:
@@ -26,6 +25,14 @@ rules:
   verbs:
   - get
   - list
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - list
+  - update
+  - watch
 - apiGroups:
   - ""
   resources:

--- a/internal/controller/amphoracontroller_controller.go
+++ b/internal/controller/amphoracontroller_controller.go
@@ -90,7 +90,7 @@ func (r *OctaviaAmphoraControllerReconciler) GetLogger(ctx context.Context) logr
 // +kubebuilder:rbac:groups="rbac.authorization.k8s.io",resources=roles,verbs=get;list;watch;create;update;patch
 // +kubebuilder:rbac:groups="rbac.authorization.k8s.io",resources=rolebindings,verbs=get;list;watch;create;update;patch
 // service account permissions that are needed to grant permission to the above
-// +kubebuilder:rbac:groups="",resources=pods,verbs=create;delete;get;list;patch;update;watch;patch
+// +kubebuilder:rbac:groups="",resources=pods,verbs=list;watch;update
 // +kubebuilder:rbac:groups="",resources=nodes,verbs=get;list
 // +kubebuilder:rbac:groups=topology.openstack.org,resources=topologies,verbs=get;list;watch;update
 

--- a/internal/controller/octavia_controller.go
+++ b/internal/controller/octavia_controller.go
@@ -108,7 +108,7 @@ func (r *OctaviaReconciler) GetLogger(ctx context.Context) logr.Logger {
 // +kubebuilder:rbac:groups="rbac.authorization.k8s.io",resources=rolebindings,verbs=get;list;watch;create;update;patch
 // service account permissions that are needed to grant permission to the above
 // +kubebuilder:rbac:groups="security.openshift.io",resourceNames=anyuid;privileged,resources=securitycontextconstraints,verbs=use
-// +kubebuilder:rbac:groups="",resources=pods,verbs=create;delete;get;list;patch;update;watch
+// +kubebuilder:rbac:groups="",resources=pods,verbs=list
 // +kubebuilder:rbac:groups="",resources=nodes,verbs=get;list
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
@@ -549,11 +549,6 @@ func (r *OctaviaReconciler) reconcileNormal(ctx context.Context, instance *octav
 			ResourceNames: []string{"anyuid", "privileged"},
 			Resources:     []string{"securitycontextconstraints"},
 			Verbs:         []string{"use"},
-		},
-		{
-			APIGroups: []string{""},
-			Resources: []string{"pods"},
-			Verbs:     []string{"create", "get", "list", "watch", "update", "patch", "delete"},
 		},
 	}
 	rbacResult, err := common_rbac.ReconcileRbac(ctx, helper, instance, rbacRules)

--- a/internal/controller/octaviaapi_controller.go
+++ b/internal/controller/octaviaapi_controller.go
@@ -93,7 +93,6 @@ func (r *OctaviaAPIReconciler) GetLogger(ctx context.Context) logr.Logger {
 // +kubebuilder:rbac:groups=ovn.openstack.org,resources=ovndbclusters,verbs=get;list;watch;
 // +kubebuilder:rbac:groups=k8s.cni.cncf.io,resources=network-attachment-definitions,verbs=get;list;watch
 // +kubebuilder:rbac:groups="security.openshift.io",resourceNames=anyuid;hostmount-anyuid,resources=securitycontextconstraints,verbs=use
-// +kubebuilder:rbac:groups="",resources=pods,verbs=create;delete;get;list;patch;update;watch;patch
 // +kubebuilder:rbac:groups=topology.openstack.org,resources=topologies,verbs=get;list;watch;update
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to

--- a/internal/controller/octaviarsyslog_controller.go
+++ b/internal/controller/octaviarsyslog_controller.go
@@ -76,7 +76,7 @@ func (r *OctaviaRsyslogReconciler) GetLogger(ctx context.Context) logr.Logger {
 // +kubebuilder:rbac:groups="rbac.authorization.k8s.io",resources=roles,verbs=get;list;watch;create;update
 // +kubebuilder:rbac:groups="rbac.authorization.k8s.io",resources=rolebindings,verbs=get;list;watch;create;update
 // service account permissions that are needed to grant permission to the above
-// +kubebuilder:rbac:groups="",resources=pods,verbs=create;delete;get;list;patch;update;watch
+// +kubebuilder:rbac:groups="",resources=pods,verbs=list;watch;update
 // +kubebuilder:rbac:groups=topology.openstack.org,resources=topologies,verbs=get;list;watch;update
 
 // Reconcile implementation of the reconcile loop for octavia rsyslog


### PR DESCRIPTION
Every controller granted full CRUD (create/delete/get/list/patch/update/ watch) on core Pods, both on its own kubebuilder marker and via the workload rbacRules passed to ReconcileRbac, without exercising most of it. Narrow each to what its own code actually uses, and regenerate config/rbac/role.yaml.

- OctaviaAPIReconciler: no Pod usage anywhere. Remove the marker entirely.
- OctaviaReconciler: only lists Pods (raw clientset, getRedisHosts). Narrow marker to list; remove the workload rbacRules pods entry entirely - nothing evidences the workload service account's containers touching the Pods API, and Octavia amphorae are OpenStack Nova VMs, not Kubernetes pods.
- OctaviaAmphoraControllerReconciler, OctaviaRsyslogReconciler: both watch Pods for readiness (Owns(&corev1.Pod{})) and list/update them (HandlePodLabeling, for the predictable-IP label). Narrow both markers to list;watch;update.

Depends-On: https://github.com/openstack-k8s-operators/openstack-operator/pull/2002