### PR TITLE
Add missing cleanup step to octavia_tls kuttl test

### DIFF
--- a/test/kuttl/tests/octavia_tls/03-cleanup-octavia.yaml
+++ b/test/kuttl/tests/octavia_tls/03-cleanup-octavia.yaml
@@ -1,0 +1,6 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+delete:
+- apiVersion: octavia.openstack.org/v1beta1
+  kind: Octavia
+  name: octavia

--- a/test/kuttl/tests/octavia_tls/03-errors.yaml
+++ b/test/kuttl/tests/octavia_tls/03-errors.yaml
@@ -1,0 +1,56 @@
+#
+# Check for:
+#
+# No OctaviaAPI CR
+# No Deployment for OctaviaAPI CR
+# No Pods in octavia Deployment
+# No Octavia Services
+#
+apiVersion: octavia.openstack.org/v1beta1
+kind: Octavia
+metadata:
+  finalizers:
+  - openstack.org/octavia
+  name: octavia
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: octavia-api
+---
+# the openshift annotations can't be checked through the deployment above
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    openshift.io/scc: anyuid
+  labels:
+    service: octavia
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    endpoint: internal
+    service: octavia
+  name: octavia-internal
+spec:
+  ports:
+    - name: octavia-internal
+  selector:
+    service: octavia
+  type: ClusterIP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    endpoint: public
+    service: octavia
+  name: octavia-public
+spec:
+  ports:
+    - name: octavia-public
+  selector:
+    service: octavia
+  type: ClusterIP


### PR DESCRIPTION
octavia_tls left its Octavia CR behind with no explicit teardown, unlike octavia_scale. The next test case (octavia_topology) reuses the same CR name in the shared namespace, updating it while kuttl's own end-of-case cleanup for octavia_tls was still deleting it asynchronously in the background - a race that deleted the CR octavia_topology had just updated, failing its assert step.

Mirror octavia_scale's explicit delete + wait-for-absence steps so kuttl blocks on full teardown before the next test case starts.